### PR TITLE
support moving ctdb enabled pods to new addresses

### DIFF
--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -176,6 +176,7 @@ def ctdb_set_node(ctx: Context) -> None:
     np = NodeParams(ctx)
     expected_pnn = np.node_number
     ctdb.add_node_to_statefile(
+        np.identity,
         np.node_ip_addr,
         int(expected_pnn or 0),
         path=np.nodes_json,

--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -37,15 +37,15 @@ _AFTER_LAST_DASH = "after-last-dash"
 
 
 def _ctdb_ok():
-    sambacc_ctdb = os.environ.get('SAMBACC_CTDB')
-    gate = 'ctdb-is-experimental'
+    sambacc_ctdb = os.environ.get("SAMBACC_CTDB")
+    gate = "ctdb-is-experimental"
     if sambacc_ctdb == gate:
         return
-    print('Using CTDB with samba-container (sambacc) is experimental.')
-    print('If you are developing or testing features for sambacc please')
-    print('set the environment variable SAMBACC_CTDB to the value:')
-    print('    ', gate)
-    print('before continuing and try again.')
+    print("Using CTDB with samba-container (sambacc) is experimental.")
+    print("If you are developing or testing features for sambacc please")
+    print("set the environment variable SAMBACC_CTDB to the value:")
+    print("    ", gate)
+    print("before continuing and try again.")
     print()
     raise Fail(gate)
 
@@ -97,8 +97,8 @@ class NodeParams:
     _ctx: Context
     node_number: typing.Optional[int] = None
     hostname: typing.Optional[str] = None
-    persistent_path: str = ''
-    nodes_json: str = ''
+    persistent_path: str = ""
+    nodes_json: str = ""
     _ip_addr: typing.Optional[str] = None
 
     def __init__(self, ctx: Context):

--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -175,6 +175,18 @@ def ctdb_set_node(ctx: Context) -> None:
     _ctdb_ok()
     np = NodeParams(ctx)
     expected_pnn = np.node_number
+
+    try:
+        ctdb.refresh_node_in_statefile(
+            np.identity,
+            np.node_ip_addr,
+            int(expected_pnn or 0),
+            path=np.nodes_json,
+        )
+        return
+    except ctdb.NodeNotPresent:
+        pass
+
     ctdb.add_node_to_statefile(
         np.identity,
         np.node_ip_addr,

--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -141,6 +141,18 @@ class NodeParams:
                 raise ValueError("can not determine node ip")
         return self._ip_addr
 
+    @property
+    def identity(self):
+        # this could be extended to use something like /etc/machine-id
+        # or whatever in the future.
+        if self.hostname:
+            return self.hostname
+        elif self.node_number:
+            return f"node-{self.node_number}"
+        else:
+            # the dashes make this an invalid dns name
+            return "-unknown-"
+
 
 @commands.command(name="ctdb-migrate", arg_func=_ctdb_migrate_args)
 def ctdb_migrate(ctx: Context) -> None:

--- a/tests/test_ctdb.py
+++ b/tests/test_ctdb.py
@@ -87,8 +87,8 @@ def test_pnn_in_nodes(tmpdir):
         fh.write(
             """
             {"nodes": [
-                {"node": "10.0.0.10", "pnn": 0, "in_nodes": true},
-                {"node": "10.0.0.11", "pnn": 1, "in_nodes": false}
+                {"node": "10.0.0.10", "pnn": 0, "state": "ready"},
+                {"node": "10.0.0.11", "pnn": 1, "state": "new"}
             ]}
         """
         )
@@ -133,7 +133,7 @@ def test_manage_nodes(tmpdir, monkeypatch):
         fh.write(
             """
             {"nodes": [
-                {"node": "10.0.0.10", "pnn": 0, "in_nodes": false}
+                {"node": "10.0.0.10", "pnn": 0, "state": "new"}
             ]}
         """
         )
@@ -147,7 +147,7 @@ def test_manage_nodes(tmpdir, monkeypatch):
         fh.write(
             """
             {"nodes": [
-                {"node": "10.0.0.10", "pnn": 0, "in_nodes": true}
+                {"node": "10.0.0.10", "pnn": 0, "state": "ready"}
             ]}
         """
         )
@@ -163,8 +163,8 @@ def test_manage_nodes(tmpdir, monkeypatch):
         fh.write(
             """
             {"nodes": [
-                {"node": "10.0.0.10", "pnn": 0, "in_nodes": true},
-                {"node": "10.0.0.11", "pnn": 1, "in_nodes": false}
+                {"node": "10.0.0.10", "pnn": 0, "state": "ready"},
+                {"node": "10.0.0.11", "pnn": 1, "state": "new"}
             ]}
         """
         )
@@ -184,8 +184,8 @@ def test_manage_nodes(tmpdir, monkeypatch):
         fh.write(
             """
             {"nodes": [
-                {"node": "10.0.0.10", "pnn": 0, "in_nodes": true},
-                {"node": "10.0.0.11", "pnn": 1, "in_nodes": false}
+                {"node": "10.0.0.10", "pnn": 0, "state": "ready"},
+                {"node": "10.0.0.11", "pnn": 1, "state": "new"}
             ]}
         """
         )
@@ -203,8 +203,8 @@ def test_manage_nodes(tmpdir, monkeypatch):
         fh.write(
             """
             {"nodes": [
-                {"node": "10.0.0.10", "pnn": 0, "in_nodes": true},
-                {"node": "10.0.0.11", "pnn": 1, "in_nodes": false}
+                {"node": "10.0.0.10", "pnn": 0, "state": "ready"},
+                {"node": "10.0.0.11", "pnn": 1, "state": "new"}
             ]}
         """
         )
@@ -222,7 +222,7 @@ def test_manage_nodes(tmpdir, monkeypatch):
     with open(nodes_json, "r") as fh:
         jdata = json.load(fh)
     assert jdata["nodes"][1]["node"] == "10.0.0.11"
-    assert jdata["nodes"][1]["in_nodes"]
+    assert jdata["nodes"][1]["state"] == "ready"
 
 
 def test_manage_nodes_refresh_fails(tmpdir, monkeypatch):
@@ -238,8 +238,8 @@ def test_manage_nodes_refresh_fails(tmpdir, monkeypatch):
         fh.write(
             """
             {"nodes": [
-                {"node": "10.0.0.10", "pnn": 0, "in_nodes": true},
-                {"node": "10.0.0.11", "pnn": 1, "in_nodes": false}
+                {"node": "10.0.0.10", "pnn": 0, "state": "ready"},
+                {"node": "10.0.0.11", "pnn": 1, "state": "new"}
             ]}
         """
         )
@@ -256,7 +256,7 @@ def test_manage_nodes_refresh_fails(tmpdir, monkeypatch):
     with open(nodes_json, "r") as fh:
         jdata = json.load(fh)
     assert jdata["nodes"][1]["node"] == "10.0.0.11"
-    assert not jdata["nodes"][1]["in_nodes"]
+    assert jdata["nodes"][1]["state"] == "new"
 
 
 def test_add_node_to_statefile(tmpdir):
@@ -269,7 +269,7 @@ def test_add_node_to_statefile(tmpdir):
         jdata = json.load(fh)
     assert jdata["nodes"][0]["node"] == "10.0.0.10"
     assert jdata["nodes"][0]["pnn"] == 0
-    assert jdata["nodes"][0]["in_nodes"]
+    assert jdata["nodes"][0]["state"] == "ready"
 
     with pytest.raises(ValueError):
         ctdb.add_node_to_statefile(
@@ -283,10 +283,10 @@ def test_add_node_to_statefile(tmpdir):
         jdata = json.load(fh)
     assert jdata["nodes"][0]["node"] == "10.0.0.10"
     assert jdata["nodes"][0]["pnn"] == 0
-    assert jdata["nodes"][0]["in_nodes"]
+    assert jdata["nodes"][0]["state"] == "ready"
     assert jdata["nodes"][1]["node"] == "10.0.0.11"
     assert jdata["nodes"][1]["pnn"] == 1
-    assert not jdata["nodes"][1]["in_nodes"]
+    assert jdata["nodes"][1]["state"] == "new"
 
 
 def test_ensure_ctdb_node_present(tmpdir):

--- a/tests/test_ctdb.py
+++ b/tests/test_ctdb.py
@@ -263,7 +263,11 @@ def test_add_node_to_statefile(tmpdir):
     nodes_json = tmpdir / "nodes.json"
 
     ctdb.add_node_to_statefile(
-        node="10.0.0.10", pnn=0, path=nodes_json, in_nodes=True
+        identity="node-0",
+        node="10.0.0.10",
+        pnn=0,
+        path=nodes_json,
+        in_nodes=True,
     )
     with open(nodes_json, "r") as fh:
         jdata = json.load(fh)
@@ -273,11 +277,19 @@ def test_add_node_to_statefile(tmpdir):
 
     with pytest.raises(ValueError):
         ctdb.add_node_to_statefile(
-            node="10.0.0.11", pnn=0, path=nodes_json, in_nodes=False
+            identity="node-0",
+            node="10.0.0.11",
+            pnn=0,
+            path=nodes_json,
+            in_nodes=False,
         )
 
     ctdb.add_node_to_statefile(
-        node="10.0.0.11", pnn=1, path=nodes_json, in_nodes=False
+        identity="node-1",
+        node="10.0.0.11",
+        pnn=1,
+        path=nodes_json,
+        in_nodes=False,
     )
     with open(nodes_json, "r") as fh:
         jdata = json.load(fh)


### PR DESCRIPTION
The pod that acts as a CTDB node may be migrated/restarted/or otherwise change IP address. Tweaking our approach to populating the nodes file we can update the CTDB cluster to use the node with it's new address.


Please review by 2021-09-09