### PR TITLE
Git checkout to a branch to avoid detached HEAD

### DIFF
--- a/tests/container/build.sh
+++ b/tests/container/build.sh
@@ -24,7 +24,7 @@ update() {
     if [[ -d "$d/.hg" ]]; then
         hg update --check "${node}"
     else
-        git checkout "${node}"
+        git checkout -b "${node}" "${node}"
     fi
 }
 


### PR DESCRIPTION
Minor improvement to hide the following advice:

_Cloning into '/var/tmp/build/sambacc'...
Note: switching to 'e3e2a53bea5d'. You are in 'detached HEAD' state._