### PR TITLE
enforce standard formatting

### DIFF
--- a/sambacc/commands/main.py
+++ b/sambacc/commands/main.py
@@ -189,7 +189,7 @@ def enable_logging(cli) -> None:
 
 
 def action_filter(cli) -> typing.Optional[str]:
-    for path in (cli.skip_if_file or []):
+    for path in cli.skip_if_file or []:
         if os.path.exists(path):
             return f"skip-if-file: {path} exists"
     return None

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -114,15 +114,15 @@ winbindd = SambaCommand("/usr/sbin/winbindd")
 
 
 def smbd_foreground():
-    return smbd["--foreground",
-                _daemon_stdout_opt("smbd"),
-                "--no-process-group"]
+    return smbd[
+        "--foreground", _daemon_stdout_opt("smbd"), "--no-process-group"
+    ]
 
 
 def winbindd_foreground():
-    return winbindd["--foreground",
-                    _daemon_stdout_opt("winbindd"),
-                    "--no-process-group"]
+    return winbindd[
+        "--foreground", _daemon_stdout_opt("winbindd"), "--no-process-group"
+    ]
 
 
 ctdbd = SambaCommand("/usr/sbin/ctdbd")

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,10 @@ deps =
     flake8
     mypy
     inotify_simple
+    black>=21.8b0
 commands =
     python setup.py check -m -s
     flake8 setup.py sambacc tests
+    black --check -v .
     mypy sambacc tests
     py.test -v tests --cov=sambacc --cov-report=html {posargs}


### PR DESCRIPTION
For a while I have been using [black](https://pypi.org/project/black/) for formatting the python code in sambacc. However, I never made it a formal part of the sambacc workflow. Now that sambacc is getting additional contributions, it's best to make the standard formatting black provides official.

These changes update a few files and adds a call to black to check (not reformat) the sambacc codebase when tox is executed.