### PR TITLE
only send dns registrations when run on "leader" node

### DIFF
--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -21,6 +21,7 @@ import argparse
 import typing
 
 from sambacc import config
+from sambacc import leader
 from sambacc import simple_waiter
 
 _INOTIFY_OK = True
@@ -134,6 +135,17 @@ def best_waiter(
         return iw.INotify(filename, print_func=print, timeout=max_timeout)
     # should max_timeout change Sleeper too? probably.
     return simple_waiter.Sleeper()
+
+
+def best_leader_locator(
+    iconfig: config.InstanceConfig,
+) -> leader.LeaderLocator:
+    """Fetch the best leader locator for our sambacc command.
+    This only makes sense to be used in a clustered scenario.
+    """
+    from sambacc import ctdb
+
+    return ctdb.CLILeaderLocator()
 
 
 commands = CommandBuilder()

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -388,10 +388,11 @@ def _node_update(nodes_json: str, real_path: str) -> bool:
         for entry in need_reload:
             entry["state"] = next_state(entry["state"])
             _logger.debug(
-                "setting node identity=[{}] pnn={} to {}",
-                entry["identity"],
-                entry["pnn"],
-                entry["state"],
+                "setting node identity=[{}] pnn={} to {}".format(
+                    entry["identity"],
+                    entry["pnn"],
+                    entry["state"],
+                )
             )
         jfile.dump(json_data, fh)
         fh.flush()

--- a/sambacc/leader.py
+++ b/sambacc/leader.py
@@ -1,0 +1,39 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2021  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import typing
+
+
+class LeaderStatus(typing.Protocol):
+    """Fetches information about the current cluster leader."""
+
+    def is_leader(self) -> bool:
+        ...
+
+
+class LeaderLocator(typing.Protocol):
+    """Acquire state needed to determine or fix a cluster leader.
+    Can be used for purely informational types or types that
+    actually acquire cluster leadership if needed.
+    """
+
+    def __enter__(self) -> LeaderStatus:
+        ...
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        ...

--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora
+FROM fedora:34
 
 RUN yum install \
     -y --setopt=install_weak_deps=False \


### PR DESCRIPTION
In some cases certain operations should only be handled by one "node" in a cluster. In the case of a samba container we want to prevent all the nodes in a cluster from submitting DNS registration when the state file changes, and only have the current leader handle the submission.

These changes add general infrastructure for determining a leader and then uses it to limit registration when ctdb is enabled.