### PR TITLE
Replace some print calls with logging

### DIFF
--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -18,6 +18,7 @@
 
 from collections import namedtuple
 import argparse
+import logging
 import typing
 
 from sambacc import config
@@ -29,6 +30,8 @@ try:
     from sambacc import inotify_waiter as iw
 except ImportError:
     _INOTIFY_OK = False
+
+_logger = logging.getLogger(__name__)
 
 
 class Fail(ValueError):
@@ -131,8 +134,10 @@ def best_waiter(
 ) -> simple_waiter.Waiter:
     """Fetch the best waiter type for our sambacc command."""
     if filename and _INOTIFY_OK:
-        print("enabling inotify support")
-        return iw.INotify(filename, print_func=print, timeout=max_timeout)
+        _logger.info("enabling inotify support")
+        return iw.INotify(
+            filename, print_func=_logger.info, timeout=max_timeout
+        )
     # should max_timeout change Sleeper too? probably.
     return simple_waiter.Sleeper()
 

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -16,12 +16,17 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import logging
+
 from sambacc import ctdb
 import sambacc.nsswitch_loader as nsswitch
 
 from . import config  # noqa: F401
 from . import users  # noqa: F401
 from .cli import commands, setup_steps, Context
+
+
+_logger = logging.getLogger(__name__)
 
 
 @setup_steps.command("nsswitch")
@@ -37,21 +42,21 @@ def _import_nsswitch(ctx: Context) -> None:
 @setup_steps.command("smb_ctdb")
 def _smb_conf_for_ctdb(ctx: Context) -> None:
     if ctx.instance_config.with_ctdb and ctx.expects_ctdb:
-        print("Enabling ctdb in samba config file")
+        _logger.info("Enabling ctdb in samba config file")
         ctdb.ensure_smb_conf(ctx.instance_config)
 
 
 @setup_steps.command("ctdb_config")
 def _ctdb_conf_for_ctdb(ctx: Context) -> None:
     if ctx.instance_config.with_ctdb and ctx.expects_ctdb:
-        print("Ensuring ctdb config")
+        _logger.info("Ensuring ctdb config")
         ctdb.ensure_ctdb_conf(ctx.instance_config)
 
 
 @setup_steps.command("ctdb_nodes")
 def _ctdb_nodes_exists(ctx: Context) -> None:
     if ctx.instance_config.with_ctdb and ctx.expects_ctdb:
-        print("Ensuring ctdb nodes file")
+        _logger.info("Ensuring ctdb nodes file")
         persistent_path = ctx.instance_config.ctdb_config()["nodes_path"]
         ctdb.ensure_ctdb_nodes(
             ctdb_nodes=ctdb.read_ctdb_nodes(persistent_path),
@@ -62,7 +67,7 @@ def _ctdb_nodes_exists(ctx: Context) -> None:
 @setup_steps.command("ctdb_etc")
 def _ctdb_etc_files(ctx: Context) -> None:
     if ctx.instance_config.with_ctdb and ctx.expects_ctdb:
-        print("Ensuring ctdb etc files")
+        _logger.info("Ensuring ctdb etc files")
         ctdb.ensure_ctdbd_etc_files()
 
 

--- a/sambacc/join.py
+++ b/sambacc/join.py
@@ -18,11 +18,14 @@
 
 import enum
 import json
+import logging
 import subprocess
 import typing
 
 from sambacc import samba_cmds
 from sambacc.simple_waiter import Waiter
+
+_logger = logging.getLogger(__name__)
 
 
 class JoinError(Exception):
@@ -172,11 +175,11 @@ def join_when_possible(
 ) -> None:
     while True:
         if joiner.did_join():
-            print("found valid join marker")
+            _logger.info("found valid join marker")
             return
         try:
             joiner.join()
-            print("successful join")
+            _logger.info("successful join")
             return
         except JoinError as err:
             if error_handler is not None:


### PR DESCRIPTION
In many cases, logging is preferable to simple print calls.
These patches replace some obvious cases where logging is better than prints.