### PR TITLE
Initial AD DC Support

### DIFF
--- a/examples/addc.json
+++ b/examples/addc.json
@@ -1,0 +1,127 @@
+{
+  "samba-container-config": "v0",
+  "configs": {
+    "demo": {
+      "instance_features": ["addc"],
+      "domain_settings": "sink",
+      "instance_name": "dc1"
+    }
+  },
+  "domain_settings": {
+    "sink": {
+      "realm": "DOMAIN1.SINK.TEST",
+      "short_domain": "DOMAIN1",
+      "admin_password": "Passw0rd"
+    }
+  },
+  "domain_groups": {
+    "sink": [
+        {"name": "supervisors"},
+        {"name": "employees"},
+        {"name": "characters"},
+        {"name": "bulk"}
+    ]
+  },
+  "domain_users": {
+    "sink": [
+      {
+        "name": "bwayne",
+        "password": "1115Rose.",
+        "given_name": "Bruce",
+        "surname": "Wayne",
+        "member_of": ["supervisors", "characters", "employees"]
+      },
+      {
+        "name": "ckent",
+        "password": "1115Rose.",
+        "given_name": "Clark",
+        "surname": "Kent",
+        "member_of": ["characters", "employees"]
+      },
+      {
+        "name": "bbanner",
+        "password": "1115Rose.",
+        "given_name": "Bruce",
+        "surname": "Banner",
+        "member_of": ["characters", "employees"]
+      },
+      {
+        "name": "pparker",
+        "password": "1115Rose.",
+        "given_name": "Peter",
+        "surname": "Parker",
+        "member_of": ["characters", "employees"]
+      },
+      {
+        "name": "user0",
+        "password": "1115Rose.",
+        "given_name": "George0",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user1",
+        "password": "1115Rose.",
+        "given_name": "George1",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user2",
+        "password": "1115Rose.",
+        "given_name": "George2",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user3",
+        "password": "1115Rose.",
+        "given_name": "George3",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user4",
+        "password": "1115Rose.",
+        "given_name": "George4",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user5",
+        "password": "1115Rose.",
+        "given_name": "George5",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user6",
+        "password": "1115Rose.",
+        "given_name": "George6",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user7",
+        "password": "1115Rose.",
+        "given_name": "George7",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user8",
+        "password": "1115Rose.",
+        "given_name": "George8",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      },
+      {
+        "name": "user9",
+        "password": "1115Rose.",
+        "given_name": "George9",
+        "surname": "Hue-Sir",
+        "member_of": ["bulk"]
+      }
+    ]
+  }
+}

--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -20,6 +20,8 @@ import logging
 import subprocess
 import typing
 
+from sambacc import samba_cmds
+
 _logger = logging.getLogger(__name__)
 
 
@@ -80,8 +82,7 @@ def _provision_cmd(
         dns_backend = "SAMBA_INTERNAL"
     if not domain:
         domain = realm.split(".")[0].upper()
-    cmd = [
-        "samba-tool",
+    cmd = samba_cmds.sambatool[
         "domain",
         "provision",
         f"--option=netbios name={dcname}",
@@ -91,7 +92,7 @@ def _provision_cmd(
         f"--realm={realm}",
         f"--domain={domain}",
         f"--adminpass={admin_password}",
-    ]
+    ].argv()
     return cmd
 
 
@@ -101,13 +102,12 @@ def _user_create_cmd(
     surname: typing.Optional[str],
     given_name: typing.Optional[str],
 ) -> typing.List[str]:
-    cmd = [
-        "samba-tool",
+    cmd = samba_cmds.sambatool[
         "user",
         "create",
         name,
         password,
-    ]
+    ].argv()
     if surname:
         cmd.append(f"--surname={surname}")
     if given_name:
@@ -116,23 +116,21 @@ def _user_create_cmd(
 
 
 def _group_add_cmd(name: str) -> typing.List[str]:
-    cmd = [
-        "samba-tool",
+    cmd = samba_cmds.sambatool[
         "group",
         "add",
         name,
-    ]
+    ].argv()
     return cmd
 
 
 def _group_add_members_cmd(
     group_name: str, members: typing.List[str]
 ) -> typing.List[str]:
-    cmd = [
-        "samba-tool",
+    cmd = samba_cmds.sambatool[
         "group",
         "addmembers",
         group_name,
         ",".join(members),
-    ]
+    ].argv()
     return cmd

--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -48,6 +48,24 @@ def provision(
     return
 
 
+def join(
+    realm: str,
+    dcname: str,
+    admin_password: str,
+    dns_backend: typing.Optional[str] = None,
+    domain: typing.Optional[str] = None,
+) -> None:
+    _logger.info(f"Joining AD domain: realm={realm}")
+    subprocess.check_call(
+        _join_cmd(
+            realm,
+            dcname,
+            admin_password=admin_password,
+            dns_backend=dns_backend,
+        )
+    )
+
+
 def create_user(
     name: str,
     password: str,
@@ -92,6 +110,30 @@ def _provision_cmd(
         f"--realm={realm}",
         f"--domain={domain}",
         f"--adminpass={admin_password}",
+    ].argv()
+    return cmd
+
+
+def _join_cmd(
+    realm: str,
+    dcname: str,
+    admin_password: str,
+    dns_backend: typing.Optional[str] = None,
+    domain: typing.Optional[str] = None,
+) -> typing.List[str]:
+    if not dns_backend:
+        dns_backend = "SAMBA_INTERNAL"
+    if not domain:
+        domain = realm.split(".")[0].upper()
+    cmd = samba_cmds.sambatool[
+        "domain",
+        "join",
+        realm,
+        "DC",
+        f"-U{domain}\\Administrator",
+        f"--option=netbios name={dcname}",
+        f"--dns-backend={dns_backend}",
+        f"--password={admin_password}",
     ].argv()
     return cmd
 

--- a/sambacc/commands/addc.py
+++ b/sambacc/commands/addc.py
@@ -1,0 +1,138 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2021  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import logging
+import os
+import shutil
+
+from sambacc import addc
+from sambacc import samba_cmds
+
+from .cli import CommandBuilder, Context
+
+_logger = logging.getLogger(__name__)
+
+_populated: str = "/var/lib/samba/POPULATED"
+_provisioned: str = "/etc/samba/smb.conf"
+
+dccommands = CommandBuilder()
+
+
+@dccommands.command(name="summary")
+def summary(ctx: Context) -> None:
+    print("Hello", ctx)
+
+
+_setup_choices = ["init-all", "provision", "populate"]
+
+
+def _dosetup(ctx: Context, step_name: str) -> bool:
+    setup = ctx.cli.setup or []
+    return ("init-all" in setup) or (step_name in setup)
+
+
+def _run_container_args(parser):
+    parser.add_argument(
+        "--setup",
+        action="append",
+        choices=_setup_choices,
+        help=(
+            "Specify one or more setup step names to preconfigure the"
+            " container environment before the server process is started."
+            " The special 'init-all' name will perform all known setup steps."
+        ),
+    )
+
+
+def _prep_provision(ctx: Context) -> None:
+    if os.path.exists(_provisioned):
+        _logger.info("Domain already provisioned")
+        return
+    _logger.info("Provisioning domain")
+
+    addc.provision(
+        realm="DOMAIN1.SINK.TEST",
+        domain="DOMAIN1",
+        dcname="dc1",
+        admin_password="Passw0rd",
+    )
+
+
+def _prep_populate(ctx: Context) -> None:
+    if os.path.exists(_populated):
+        _logger.info("populated marker exists")
+        return
+    _logger.info("Populating domain with default entries")
+
+    addc.create_group("supervisors")
+    addc.create_group("employees")
+    addc.create_group("characters")
+    addc.create_group("bulk")
+
+    pw = "1115Rose."
+    addc.create_user(name="johnm", password=pw, surname="John", given_name="M")
+    addc.create_user(
+        name="ckent", password=pw, surname="Clark", given_name="Kent"
+    )
+    addc.create_user(
+        name="bwayne", password=pw, surname="Bruce", given_name="Wayne"
+    )
+    addc.create_user(
+        name="bbanner", password=pw, surname="Bruce", given_name="Banner"
+    )
+    addc.create_user(
+        name="pparker", password=pw, surname="Peter", given_name="Parker"
+    )
+
+    addc.add_group_members(group_name="supervisors", members=["johnm"])
+    addc.add_group_members(
+        group_name="employees",
+        members=["johnm", "ckent", "bwayne", "pparker", "bbanner"],
+    )
+    addc.add_group_members(
+        group_name="characters",
+        members=["ckent", "bwayne", "pparker", "bbanner"],
+    )
+
+    for i in range(42):
+        uname = f"user{i}"
+        addc.create_user(
+            name=uname, password=pw, surname="Hue-Sir", given_name=f"George{i}"
+        )
+        addc.add_group_members(group_name="bulk", members=[uname])
+
+    # "touch" the populated marker
+    with open(_populated, "w"):
+        pass
+
+
+def _prep_krb5_conf(ctx: Context) -> None:
+    shutil.copy("/var/lib/samba/private/krb5.conf", "/etc/krb5.conf")
+
+
+@dccommands.command(name="run", arg_func=_run_container_args)
+def run(ctx: Context) -> None:
+    _logger.info("Running AD DC container")
+    if _dosetup(ctx, "provision"):
+        _prep_provision(ctx)
+    if _dosetup(ctx, "populate"):
+        _prep_populate(ctx)
+
+    _prep_krb5_conf(ctx)
+    _logger.info("Starting samba server")
+    samba_cmds.execute(samba_cmds.samba_dc_foreground())

--- a/sambacc/commands/addc.py
+++ b/sambacc/commands/addc.py
@@ -67,6 +67,10 @@ def _run_container_args(parser):
             " The special 'init-all' name will perform all known setup steps."
         ),
     )
+    parser.add_argument(
+        "--name",
+        help="Specify a custom name for the dc, overriding the config file.",
+    )
 
 
 def _prep_provision(ctx: Context) -> None:
@@ -76,10 +80,11 @@ def _prep_provision(ctx: Context) -> None:
     domconfig = ctx.instance_config.domain()
     _logger.info(f"Provisioning domain: {domconfig.realm}")
 
+    dcname = ctx.cli.name or domconfig.dcname
     addc.provision(
         realm=domconfig.realm,
         domain=domconfig.short_domain,
-        dcname=domconfig.dcname,
+        dcname=dcname,
         admin_password=domconfig.admin_password,
     )
 
@@ -91,10 +96,11 @@ def _prep_join(ctx: Context) -> None:
     domconfig = ctx.instance_config.domain()
     _logger.info(f"Provisioning domain: {domconfig.realm}")
 
+    dcname = ctx.cli.name or domconfig.dcname
     addc.join(
         realm=domconfig.realm,
         domain=domconfig.short_domain,
-        dcname=domconfig.dcname,
+        dcname=dcname,
         admin_password=domconfig.admin_password,
     )
 

--- a/sambacc/commands/dcmain.py
+++ b/sambacc/commands/dcmain.py
@@ -1,0 +1,52 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2021  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from . import addc
+from .cli import Fail
+from .main import (
+    CommandContext,
+    action_filter,
+    enable_logging,
+    env_to_cli,
+    global_args,
+    pre_action,
+)
+
+
+default_cfunc = addc.summary
+
+
+def main(args=None) -> None:
+    cli = addc.dccommands.assemble(arg_func=global_args).parse_args(args)
+    env_to_cli(cli)
+    enable_logging(cli)
+    if not cli.identity:
+        raise Fail("missing container identity")
+
+    pre_action(cli)
+    skip = action_filter(cli)
+    if skip:
+        print(f"Action skipped: {skip}")
+        return
+    cfunc = getattr(cli, "cfunc", default_cfunc)
+    cfunc(CommandContext(cli))
+    return
+
+
+if __name__ == "__main__":
+    main()

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -36,6 +36,7 @@ GroupEntryTuple = typing.Tuple[str, str, str, str]
 SMB_CONF = "/etc/samba/smb.conf"
 
 CTDB: typing.Final[str] = "ctdb"
+ADDC: typing.Final[str] = "addc"
 FEATURES: typing.Final[str] = "instance_features"
 
 
@@ -151,6 +152,10 @@ class InstanceConfig:
     @property
     def with_ctdb(self) -> bool:
         return CTDB in self.iconfig.get(FEATURES, [])
+
+    @property
+    def with_addc(self) -> bool:
+        return ADDC in self.iconfig.get(FEATURES, [])
 
     def ctdb_smb_config(self) -> CTDBSambaConfig:
         if not self.with_ctdb:

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -35,8 +35,8 @@ GroupEntryTuple = typing.Tuple[str, str, str, str]
 # the standard location for samba's smb.conf
 SMB_CONF = "/etc/samba/smb.conf"
 
-CTDB = "ctdb"
-FEATURES = "instance_features"
+CTDB: typing.Final[str] = "ctdb"
+FEATURES: typing.Final[str] = "instance_features"
 
 
 def read_config_files(fnames) -> GlobalConfig:
@@ -149,7 +149,7 @@ class InstanceConfig:
             yield uentry.vgroup()
 
     @property
-    def with_ctdb(self):
+    def with_ctdb(self) -> bool:
         return CTDB in self.iconfig.get(FEATURES, [])
 
     def ctdb_smb_config(self) -> CTDBSambaConfig:

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -161,6 +161,8 @@ ltdbtool = CommandArgs("ltdbtool")
 
 ctdb = SambaCommand("ctdb")
 
+sambatool = SambaCommand("samba-tool")
+
 
 def encode(value: typing.Union[str, bytes, None]) -> bytes:
     if value is None:

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -140,6 +140,8 @@ smbd = SambaCommand("/usr/sbin/smbd")
 
 winbindd = SambaCommand("/usr/sbin/winbindd")
 
+samba_dc = SambaCommand("/usr/sbin/samba")
+
 
 def smbd_foreground():
     return smbd[
@@ -151,6 +153,10 @@ def winbindd_foreground():
     return winbindd[
         "--foreground", _daemon_stdout_opt("winbindd"), "--no-process-group"
     ]
+
+
+def samba_dc_foreground():
+    return samba_dc["--foreground"]
 
 
 ctdbd = SambaCommand("/usr/sbin/ctdbd")

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,9 +19,11 @@ include_package_data = True
 [options.entry_points]
 console_scripts =
     samba-container = sambacc.commands.main:main
+    samba-dc-container = sambacc.commands.dcmain:main
 
 [options.data_files]
 share/sambacc/examples =
   examples/ctdb.json
   examples/example1.json
   examples/minimal.json
+  examples/addc.json

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     mypy
     inotify_simple
     black>=21.8b0
+    dnspython
 commands =
     flake8 sambacc tests
     black --check -v .


### PR DESCRIPTION
While it's a bit rough and simplistic, these changes add AD DC support to sambacc. Currently, there's one new script `samba-dc-container` that supports one subcommand `run`. It also has setup actions for `provision` and `join` and can also wait for the domain to appear with `wait-domain` which will poll until the ldap srv record exists for the domain.

With this sambacc supports (by default) the same behavior as the hard-coded scripts in samba-container's ad-server container image. In addition, you can customize your domain and initial users through the sambacc config json. You can then join additional containers to the domain.

I probably could have added more unit tests but the layer between us and samba-tool is thin currently. In the future, some of the stuff like user and groups creation may be better done via function calls into samba's python libs, but right now we just shell out to the cli.