### PR TITLE
do not try to enable debugging for ldbtool

### DIFF
--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -171,4 +171,4 @@ def encode(value: typing.Union[str, bytes, None]) -> bytes:
 
 def execute(cmd: SambaCommand) -> None:
     """Exec into the command specified (without forking)."""
-    os.execvp(cmd.name, cmd.argv())
+    os.execvp(cmd.name, cmd.argv())  # pragma: no cover

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -35,8 +35,9 @@ _DAEMON_CLI_STDOUT_OPT: str = "daemon_cli_debug_output"
 def get_samba_specifics() -> typing.Set[str]:
     value = os.environ.get("SAMBA_SPECIFICS", "")
     out = set()
-    for v in value.split(","):
-        out.add(v)
+    if value:
+        for v in value.split(","):
+            out.add(v)
     return out
 
 

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -156,7 +156,7 @@ ctdbd = SambaCommand("/usr/sbin/ctdbd")
 
 ctdbd_foreground = ctdbd["--interactive"]
 
-ltdbtool = SambaCommand("ltdbtool")
+ltdbtool = CommandArgs("ltdbtool")
 
 ctdb = SambaCommand("ctdb")
 

--- a/tests/test_samba_cmds.py
+++ b/tests/test_samba_cmds.py
@@ -73,3 +73,21 @@ def test_execute():
     else:
         _, status = os.waitpid(pid, 0)
         assert status == 0
+
+
+def test_create_command_args():
+    # this is the simpler base class for SambaCommand. It lacks
+    # the samba debug level option.
+    cmd = sambacc.samba_cmds.CommandArgs("something")
+    assert cmd.name == "something"
+    cmd2 = cmd["nice"]
+    assert cmd.name == "something"
+    assert list(cmd) == ["something"]
+    assert list(cmd2) == ["something", "nice"]
+
+
+def test_command_args_repr():
+    r = str(sambacc.samba_cmds.CommandArgs("something", ["nice"]))
+    assert r.startswith("CommandArgs")
+    assert "something" in r
+    assert "nice" in r

--- a/tests/test_samba_cmds.py
+++ b/tests/test_samba_cmds.py
@@ -91,3 +91,44 @@ def test_command_args_repr():
     assert r.startswith("CommandArgs")
     assert "something" in r
     assert "nice" in r
+
+
+def test_get_samba_specifics(monkeypatch):
+    monkeypatch.setenv("SAMBA_SPECIFICS", "")
+    ss = sambacc.samba_cmds.get_samba_specifics()
+    assert not ss
+
+    monkeypatch.setenv("SAMBA_SPECIFICS", "wibble,quux")
+    ss = sambacc.samba_cmds.get_samba_specifics()
+    assert ss
+    assert len(ss) == 2
+    assert "wibble" in ss
+    assert "quux" in ss
+
+
+def test_smbd_foreground(monkeypatch):
+    monkeypatch.setenv("SAMBA_SPECIFICS", "")
+    sf = sambacc.samba_cmds.smbd_foreground()
+    assert "smbd" in sf.name
+    assert "--log-stdout" in sf.argv()
+    assert "--debug-stdout" not in sf.argv()
+
+    monkeypatch.setenv("SAMBA_SPECIFICS", "daemon_cli_debug_output")
+    sf = sambacc.samba_cmds.smbd_foreground()
+    assert "smbd" in sf.name
+    assert "--log-stdout" not in sf.argv()
+    assert "--debug-stdout" in sf.argv()
+
+
+def test_winbindd_foreground(monkeypatch):
+    monkeypatch.setenv("SAMBA_SPECIFICS", "")
+    wf = sambacc.samba_cmds.winbindd_foreground()
+    assert "winbindd" in wf.name
+    assert "--stdout" in wf.argv()
+    assert "--debug-stdout" not in wf.argv()
+
+    monkeypatch.setenv("SAMBA_SPECIFICS", "daemon_cli_debug_output")
+    wf = sambacc.samba_cmds.winbindd_foreground()
+    assert "winbindd" in wf.name
+    assert "--stdout" not in wf.argv()
+    assert "--debug-stdout" in wf.argv()


### PR DESCRIPTION
Fixes: #22

The main point for the PR is to fix the issue where ltdbtool fails when run with samba's standard approach for setting debug level on the cli. This tool is very simple and low level and thus is not built to accept that option. 
To make this change I factored a new base class out of SambaCommand and made our ltdbtool wrapper based on that.

While I was in the neighborhood I added tests for the new class as well some of the previously uncovered functions in samba_cmds.