### PR TITLE
Support updating samba config

### DIFF
--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -16,12 +16,28 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import argparse
+import functools
+import logging
+import subprocess
 import sys
+import typing
 
+from sambacc import config
+from sambacc import samba_cmds
+from sambacc.simple_waiter import watch
 import sambacc.netcmd_loader as nc
 import sambacc.paths as paths
 
-from .cli import commands, setup_steps, Context
+from .cli import (
+    Context,
+    best_leader_locator,
+    best_waiter,
+    commands,
+    setup_steps,
+)
+
+_logger = logging.getLogger(__name__)
 
 
 @commands.command(name="print-config")
@@ -43,3 +59,96 @@ def import_config(ctx: Context) -> None:
 
     loader = nc.NetCmdLoader()
     loader.import_config(ctx.instance_config)
+
+
+def _update_config_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--watch",
+        action="store_true",
+        help=("If set, watch the source for changes and update config."),
+    )
+
+
+def _read_config(ctx: Context) -> config.InstanceConfig:
+    cfgs = ctx.cli.config or []
+    return config.read_config_files(cfgs).get(ctx.cli.identity)
+
+
+def _update_config(
+    current: config.InstanceConfig,
+    previous: typing.Optional[config.InstanceConfig],
+    ensure_paths: bool = True,
+    notify_server: bool = True,
+) -> typing.Tuple[config.InstanceConfig, bool]:
+    """Compare the current and previous instance configurations. If they
+    differ, ensure any new paths, update the samba config, and inform any
+    running smbds of the new configuration.  Return the current config and a
+    boolean indicating if the instance configs differed.
+    """
+    # has the config changed?
+    changed = current != previous
+    # ensure share paths exist
+    if changed and ensure_paths:
+        for share in current.shares():
+            path = share.path()
+            if not path:
+                continue
+            _logger.info(f"Ensuring share path: {path}")
+            paths.ensure_share_dirs(path)
+    # update smb config
+    if changed:
+        _logger.info("Updating samba configuration")
+        loader = nc.NetCmdLoader()
+        loader.import_config(current)
+    # notify smbd of changes
+    if changed and notify_server:
+        subprocess.check_call(
+            list(samba_cmds.smbcontrol["smbd", "reload-config"])
+        )
+    return current, changed
+
+
+def _exec_if_leader(
+    ctx: Context,
+    cond_func: typing.Callable[..., typing.Tuple[config.InstanceConfig, bool]],
+) -> typing.Callable[..., typing.Tuple[config.InstanceConfig, bool]]:
+    """Run the cond func only on "nodes" that are the cluster leader."""
+    # CTDB status and leader detection is not changeable at runtime.
+    # we do not need to account for it changing in the updated config file(s)
+    @functools.wraps(cond_func)
+    def _call_if_leader(
+        current: config.InstanceConfig, previous: config.InstanceConfig
+    ) -> typing.Tuple[config.InstanceConfig, bool]:
+        with best_leader_locator(ctx.instance_config) as ll:
+            if not ll.is_leader():
+                _logger.info("skipping config update. node not leader")
+                return previous, False
+            _logger.info("checking for update. node is leader")
+            return cond_func(current, previous)
+
+    return _call_if_leader
+
+
+@commands.command(name="update-config", arg_func=_update_config_args)
+def update_config(ctx: Context) -> None:
+    _get_config = functools.partial(_read_config, ctx)
+    _cmp_func = _update_config
+
+    if ctx.instance_config.with_ctdb:
+        _logger.info("enabling ctdb support: will check for leadership")
+        _cmp_func = _exec_if_leader(ctx, _cmp_func)
+
+    if ctx.cli.watch:
+        _logger.info("will watch configuration source")
+        waiter = best_waiter(ctx.cli.config)
+        watch(
+            waiter,
+            ctx.instance_config,
+            _get_config,
+            _cmp_func,
+        )
+    else:
+        # we pass None as the previous config so that the command is
+        # not nearly always a no-op when run from the command line.
+        _cmp_func(_get_config(), None)
+    return

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -71,7 +71,7 @@ def _ctdb_etc_files(ctx: Context) -> None:
         ctdb.ensure_ctdbd_etc_files()
 
 
-_init_setup_steps = [
+_default_setup_steps = [
     "config",
     "users",
     "smb_ctdb",
@@ -88,7 +88,7 @@ def setup_step_names():
 @commands.command(name="init")
 def init_container(ctx: Context, steps=None) -> None:
     """Initialize the entire container environment."""
-    steps = _init_setup_steps if steps is None else list(steps)
+    steps = _default_setup_steps if steps is None else list(steps)
     cmds = setup_steps.dict()
     for step_name in steps:
         cmds[step_name].cmd_func(ctx)

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -19,6 +19,7 @@
 import logging
 
 from sambacc import ctdb
+from sambacc import paths
 import sambacc.nsswitch_loader as nsswitch
 
 from . import config  # noqa: F401
@@ -69,6 +70,23 @@ def _ctdb_etc_files(ctx: Context) -> None:
     if ctx.instance_config.with_ctdb and ctx.expects_ctdb:
         _logger.info("Ensuring ctdb etc files")
         ctdb.ensure_ctdbd_etc_files()
+
+
+@setup_steps.command("share_paths")
+@commands.command(name="ensure-share-paths")
+def ensure_share_paths(ctx: Context) -> None:
+    """Ensure the paths defined by the configuration exist."""
+    # currently this is completely ignorant of things like vfs
+    # modules that might "virtualize" the share path. It just
+    # assumes that the path in the configuration is an absolute
+    # path in the file system.
+    for share in ctx.instance_config.shares():
+        path = share.path()
+        if not path:
+            continue
+        _logger.info(f"Ensuring share path: {path}")
+        paths.ensure_share_dirs(path)
+        # TODO: set proper perms/acls for a "share root"
 
 
 _default_setup_steps = [

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -202,6 +202,17 @@ class InstanceConfig:
         for n, entry in enumerate(dgroups):
             yield DomainGroupEntry(self, entry, n)
 
+    def __eq__(self, other: typing.Any) -> bool:
+        if isinstance(other, InstanceConfig) and self.iconfig == other.iconfig:
+            self_shares = _shares_data(self.gconfig, self.iconfig)
+            other_shares = _shares_data(other.gconfig, other.iconfig)
+            self_globals = _globals_data(self.gconfig, self.iconfig)
+            other_globals = _globals_data(other.gconfig, other.iconfig)
+            return (
+                self_shares == other_shares and self_globals == other_globals
+            )
+        return False
+
 
 class CTDBSambaConfig:
     def global_options(self) -> typing.Iterable[typing.Tuple[str, str]]:
@@ -341,3 +352,19 @@ class DomainUserEntry(UserEntry):
 
 class DomainGroupEntry(GroupEntry):
     pass
+
+
+def _shares_data(gconfig: GlobalConfig, iconfig: dict) -> list:
+    try:
+        shares = iconfig["shares"]
+    except KeyError:
+        return []
+    return [gconfig.data["shares"][n] for n in shares]
+
+
+def _globals_data(gconfig: GlobalConfig, iconfig: dict) -> list:
+    try:
+        gnames = iconfig["globals"]
+    except KeyError:
+        return []
+    return [gconfig.data["globals"][n] for n in gnames]

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -225,6 +225,14 @@ class ShareConfig:
         share_section = self.gconfig.data["shares"][self.name]
         return iter(share_section.get("options", {}).items())
 
+    def path(self) -> typing.Optional[str]:
+        """Return the path value from the smb.conf options."""
+        share_section = self.gconfig.data["shares"][self.name]
+        try:
+            return share_section["options"]["path"]
+        except KeyError:
+            return None
+
 
 class UserEntry:
     def __init__(self, iconf: InstanceConfig, urec: dict, num: int):

--- a/sambacc/container_dns.py
+++ b/sambacc/container_dns.py
@@ -109,6 +109,7 @@ def parse_and_update(
     return hs, updated
 
 
+# TODO: replace this with the common version added to simple_waiter
 def watch(domain, source, update_func, pause_func, print_func=None):
     previous = None
     while True:

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -506,7 +506,7 @@ class CLILeaderLocator:
         pnn_cmd = samba_cmds.ctdb["pnn"]
         try:
             out = subprocess.check_output(list(pnn_cmd))
-            mypnn = str(out).strip()
+            mypnn = out.decode("utf8").strip()
         except subprocess.CalledProcessError as err:
             _logger.error(f"command {pnn_cmd!r} failed: {err!r}")
         except FileNotFoundError:
@@ -515,7 +515,7 @@ class CLILeaderLocator:
         recmaster_cmd = samba_cmds.ctdb["recmaster"]
         try:
             out = subprocess.check_output(list(recmaster_cmd))
-            recmaster = str(out).strip()
+            recmaster = out.decode("utf8").strip()
         except subprocess.CalledProcessError as err:
             _logger.error(f"command {recmaster_cmd!r} failed: {err!r}")
         except FileNotFoundError:

--- a/sambacc/inotify_waiter.py
+++ b/sambacc/inotify_waiter.py
@@ -60,6 +60,9 @@ class INotify:
         if self.print_func:
             self.print_func("[inotify waiter] {}".format(msg))
 
+    def acted(self) -> None:
+        return  # noop for inotify waiter
+
     def wait(self) -> None:
         next(self._wait())
 

--- a/sambacc/paths.py
+++ b/sambacc/paths.py
@@ -20,7 +20,7 @@ import errno
 import os
 
 
-def ensure_samba_dirs(root="/") -> None:
+def ensure_samba_dirs(root: str = "/") -> None:
     """Ensure that certain directories that samba servers expect will
     exist. This is useful when mapping iniitally empty dirs into
     the container.

--- a/sambacc/paths.py
+++ b/sambacc/paths.py
@@ -44,3 +44,14 @@ def _mkdir(path: str) -> None:
     except OSError as err:
         if getattr(err, "errno", 0) != errno.EEXIST:
             raise
+
+
+def ensure_share_dirs(path: str, root: str = "/") -> None:
+    """Ensure that the given path exists.
+    The optional root argument allows "reparenting" the path
+    into a virtual root dir.
+    """
+    while path.startswith("/"):
+        path = path[1:]
+    path = os.path.join(root, path)
+    os.makedirs(path, exist_ok=True)

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -176,6 +176,8 @@ ctdb = SambaCommand("ctdb")
 
 sambatool = SambaCommand("samba-tool")
 
+smbcontrol = SambaCommand("smbcontrol")
+
 
 def encode(value: typing.Union[str, bytes, None]) -> bytes:
     if value is None:

--- a/sambacc/simple_waiter.py
+++ b/sambacc/simple_waiter.py
@@ -53,9 +53,19 @@ class Sleeper:
     def wait(self):
         self._sleep(next(self._times))
 
+    def acted(self):
+        """Inform the sleeper the caller reacted to a change and
+        the sleeps should be reset.
+        """
+        self.times = generate_sleeps()
+
 
 class Waiter(typing.Protocol):
     """Waiter protocol - interfaces common to all waiters."""
 
     def wait(self) -> None:
+        ...
+
+    def acted(self) -> None:
+        """Inform that waiter that changes were made."""
         ...

--- a/sambacc/simple_waiter.py
+++ b/sambacc/simple_waiter.py
@@ -69,3 +69,28 @@ class Waiter(typing.Protocol):
     def acted(self) -> None:
         """Inform that waiter that changes were made."""
         ...
+
+
+def watch(
+    waiter: Waiter,
+    initial_value: typing.Any,
+    fetch_func: typing.Callable[..., typing.Any],
+    compare_func: typing.Callable[..., typing.Tuple[typing.Any, bool]],
+) -> None:
+    """A very simple "event loop" that fetches current data with
+    `fetch_func`, compares and updates state with `compare_func` and
+    then waits for new events with `pause_func`.
+    """
+    previous = initial_value
+    while True:
+        try:
+            previous, updated = compare_func(fetch_func(), previous)
+        except FileNotFoundError:
+            updated = False
+            previous = None
+        try:
+            if updated:
+                waiter.acted()
+            waiter.wait()
+        except KeyboardInterrupt:
+            return

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -1,0 +1,282 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2022  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import argparse
+import functools
+import os
+
+import sambacc.config
+import sambacc.paths
+
+import sambacc.commands.config
+
+
+config1 = """
+{
+    "samba-container-config": "v0",
+    "configs": {
+        "updateme":{
+          "shares": ["uno"],
+          "globals": ["global0"]
+        }
+    },
+    "shares": {
+       "uno": {
+          "options": {
+              "path": "/srv/data/uno"
+          }
+       }
+    },
+    "globals": {
+        "global0": {
+           "options": {
+             "server min protocol": "SMB2"
+           }
+        }
+    }
+}
+"""
+
+config2 = """
+{
+    "samba-container-config": "v0",
+    "configs": {
+        "updateme":{
+          "shares": ["uno", "dos"],
+          "globals": ["global0"]
+        }
+    },
+    "shares": {
+       "uno": {
+          "options": {
+              "path": "/srv/data/uno"
+          }
+       },
+       "dos": {
+          "options": {
+              "path": "/srv/data/dos"
+          }
+       }
+    },
+    "globals": {
+        "global0": {
+           "options": {
+             "server min protocol": "SMB2"
+           }
+        }
+    }
+}
+"""
+
+
+class FakeContext:
+    cli: argparse.Namespace
+    instance_config: sambacc.config.InstanceConfig
+
+    def __init__(self, opts, instance_config):
+        self.cli = argparse.Namespace()
+        self.instance_config = instance_config
+        for k, v in opts.items():
+            setattr(self.cli, k, v)
+
+    @classmethod
+    def defaults(cls, cfg_path, watch=False):
+        with open(cfg_path, "w") as fh:
+            fh.write(config1)
+
+        config = [cfg_path]
+        identity = "updateme"
+        ctx = cls(
+            {
+                "watch": watch,
+                "config": config,
+                "identity": identity,
+            },
+            sambacc.config.read_config_files(config).get(identity),
+        )
+        return ctx
+
+
+class FakeWaiter:
+    def __init__(self, attempts=None):
+        self.count = 0
+        self.on_count = {}
+        self.attempts = attempts
+
+    def acted(self):
+        pass
+
+    def wait(self):
+        if self.attempts is not None and self.count >= self.attempts:
+            raise KeyboardInterrupt()
+        wf = self.on_count.get(self.count, None)
+        if wf is not None:
+            wf()
+        self.count += 1
+
+
+def _gen_fake_cmd(fake_path, chkpath, pnn="0"):
+    with open(fake_path, "w") as fh:
+        fh.write("#!/bin/sh\n")
+        fh.write(f'echo "$@" >> {chkpath}\n')
+        fh.write(f'[ "$1" = ctdb ] && echo {pnn}" " ; \n')
+        fh.write("exit 0\n")
+    os.chmod(fake_path, 0o755)
+
+
+def test_update_config_changed(tmp_path, monkeypatch):
+    cfg_path = str(tmp_path / "config")
+    fake = tmp_path / "fake.sh"
+    chkpath = tmp_path / ".executed"
+    _gen_fake_cmd(fake, str(chkpath))
+    monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
+
+    ctx = FakeContext.defaults(cfg_path)
+    with open(cfg_path, "w") as fh:
+        fh.write(config2)
+    monkeypatch.setattr(
+        sambacc.paths,
+        "ensure_share_dirs",
+        functools.partial(
+            sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
+        ),
+    )
+    sambacc.commands.config.update_config(ctx)
+
+    assert os.path.exists(chkpath)
+    chk = open(chkpath).readlines()
+    assert any(("net" in line) for line in chk)
+    assert any(("smbcontrol" in line) for line in chk)
+
+
+def test_update_config_changed_ctdb(tmp_path, monkeypatch):
+    cfg_path = str(tmp_path / "config")
+    fake = tmp_path / "fake.sh"
+    chkpath = tmp_path / ".executed"
+    _gen_fake_cmd(fake, str(chkpath))
+    monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
+
+    ctx = FakeContext.defaults(cfg_path)
+    ctx.instance_config.iconfig["instance_features"] = ["ctdb"]
+    assert ctx.instance_config.with_ctdb
+    with open(cfg_path, "w") as fh:
+        fh.write(config2)
+    monkeypatch.setattr(
+        sambacc.paths,
+        "ensure_share_dirs",
+        functools.partial(
+            sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
+        ),
+    )
+    sambacc.commands.config.update_config(ctx)
+
+    assert os.path.exists(chkpath)
+    chk = open(chkpath).readlines()
+    assert any(("net" in line) for line in chk)
+    assert any(("smbcontrol" in line) for line in chk)
+
+
+def test_update_config_ctdb_notleader(tmp_path, monkeypatch):
+    cfg_path = str(tmp_path / "config")
+    fake = tmp_path / "fake.sh"
+    chkpath = tmp_path / ".executed"
+    _gen_fake_cmd(fake, str(chkpath), pnn="")
+    monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
+
+    ctx = FakeContext.defaults(cfg_path)
+    ctx.instance_config.iconfig["instance_features"] = ["ctdb"]
+    assert ctx.instance_config.with_ctdb
+    with open(cfg_path, "w") as fh:
+        fh.write(config2)
+    monkeypatch.setattr(
+        sambacc.paths,
+        "ensure_share_dirs",
+        functools.partial(
+            sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
+        ),
+    )
+    sambacc.commands.config.update_config(ctx)
+
+    assert os.path.exists(chkpath)
+    chk = open(chkpath).readlines()
+    assert not any(("net" in line) for line in chk)
+    assert not any(("smbcontrol" in line) for line in chk)
+
+
+def test_update_config_watch_waiter_expires(tmp_path, monkeypatch):
+    cfg_path = str(tmp_path / "config")
+    fake = tmp_path / "fake.sh"
+    chkpath = tmp_path / ".executed"
+    _gen_fake_cmd(fake, str(chkpath))
+    monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
+
+    fake_waiter = FakeWaiter(attempts=5)
+
+    def _fake_waiter(*args, **kwargs):
+        return fake_waiter
+
+    monkeypatch.setattr(sambacc.commands.config, "best_waiter", _fake_waiter)
+
+    ctx = FakeContext.defaults(cfg_path, watch=True)
+    monkeypatch.setattr(
+        sambacc.paths,
+        "ensure_share_dirs",
+        functools.partial(
+            sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
+        ),
+    )
+    sambacc.commands.config.update_config(ctx)
+
+    assert not os.path.exists(chkpath)
+    assert fake_waiter.count == 5
+
+
+def test_update_config_watch_waiter_trigger3(tmp_path, monkeypatch):
+    cfg_path = str(tmp_path / "config")
+    fake = tmp_path / "fake.sh"
+    chkpath = tmp_path / ".executed"
+    _gen_fake_cmd(fake, str(chkpath))
+    monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
+
+    fake_waiter = FakeWaiter(attempts=5)
+
+    def _fake_waiter(*args, **kwargs):
+        return fake_waiter
+
+    def _new_conf():
+        with open(cfg_path, "w") as fh:
+            fh.write(config2)
+
+    monkeypatch.setattr(sambacc.commands.config, "best_waiter", _fake_waiter)
+    fake_waiter.on_count[3] = _new_conf
+
+    ctx = FakeContext.defaults(cfg_path, watch=True)
+    monkeypatch.setattr(
+        sambacc.paths,
+        "ensure_share_dirs",
+        functools.partial(
+            sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
+        ),
+    )
+    sambacc.commands.config.update_config(ctx)
+
+    assert os.path.exists(chkpath)
+    chk = open(chkpath).readlines()
+    assert any(("net" in line) for line in chk)
+    assert any(("smbcontrol" in line) for line in chk)
+    assert fake_waiter.count == 5

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -302,6 +302,19 @@ class TestConfig(unittest.TestCase):
             else:
                 raise AssertionError(share.name)
 
+    def test_get_share_paths(self):
+        fh = io.StringIO(config1)
+        g = sambacc.config.GlobalConfig(fh)
+        ic = g.get("foobar")
+        shares = list(ic.shares())
+        for share in shares:
+            if share.name == "demo":
+                assert share.path() == "/mnt/demo"
+            elif share.name == "stuff":
+                assert share.path() == "/mnt/stuff"
+            else:
+                raise AssertionError(share.name)
+
     def test_unique_name(self):
         fh = io.StringIO(config2)
         g = sambacc.config.GlobalConfig(fh)
@@ -556,3 +569,33 @@ def test_ad_dc_bad_memeber_of():
 
     with pytest.raises(ValueError):
         list(i1.domain_users())
+
+
+def test_share_config_no_path():
+    j = """{
+    "samba-container-config": "v0",
+    "configs": {
+        "foobar":{
+          "shares": ["flunk"],
+          "globals": ["global0"]
+        }
+    },
+    "shares": {
+       "flunk": {
+          "options": {}
+       }
+    },
+    "globals": {
+        "global0": {
+           "options": {
+             "server min protocol": "SMB2"
+           }
+        }
+    }
+}"""
+    fh = io.StringIO(j)
+    g = sambacc.config.GlobalConfig(fh)
+    ic = g.get("foobar")
+    shares = list(ic.shares())
+    assert len(shares) == 1
+    assert shares[0].path() is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -700,6 +700,10 @@ def test_share_config_no_path():
             False,
         ),
     ],
+    # setting ID to a numeric range makes it a lot easier to read the
+    # output on the console, versus having pytest plop two large json
+    # blobs for each "row" of inputs
+    ids=iter(range(100)),
 )
 def test_instance_config_equality(json_a, json_b, iname, expect_equal):
     gca = sambacc.config.GlobalConfig(io.StringIO(json_a))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -599,3 +599,114 @@ def test_share_config_no_path():
     shares = list(ic.shares())
     assert len(shares) == 1
     assert shares[0].path() is None
+
+
+@pytest.mark.parametrize(
+    "json_a,json_b,iname,expect_equal",
+    [
+        (config1, config1, "foobar", True),
+        (addc_config1, addc_config1, "demo", True),
+        (config1, config2, "foobar", False),
+        (
+            """{
+    "samba-container-config": "v0",
+    "configs": {
+        "foobar":{
+          "shares": ["flunk"],
+          "globals": ["global0"]
+        }
+    },
+    "shares": {
+       "flunk": {
+          "options": {"path": "/mnt/yikes"}
+       }
+    },
+    "globals": {
+        "global0": {
+           "options": {
+             "server min protocol": "SMB2"
+           }
+        }
+    }
+}""",
+            """{
+    "samba-container-config": "v0",
+    "configs": {
+        "foobar":{
+          "shares": ["flunk"],
+          "globals": ["global0"]
+        }
+    },
+    "shares": {
+       "flunk": {
+          "options": {"path": "/mnt/psych"}
+       }
+    },
+    "globals": {
+        "global0": {
+           "options": {
+             "server min protocol": "SMB2"
+           }
+        }
+    }
+}""",
+            "foobar",
+            False,
+        ),
+        (
+            """{
+    "samba-container-config": "v0",
+    "configs": {
+        "foobar":{
+          "shares": ["flunk"],
+          "globals": ["global0"]
+        }
+    },
+    "shares": {
+       "flunk": {
+          "options": {"path": "/mnt/yikes"}
+       }
+    },
+    "globals": {
+        "global0": {
+           "options": {
+             "server min protocol": "SMB2"
+           }
+        }
+    }
+}""",
+            """{
+    "samba-container-config": "v0",
+    "configs": {
+        "foobar":{
+          "shares": ["flunk"],
+          "globals": ["global0"]
+        }
+    },
+    "shares": {
+       "flunk": {
+          "options": {"path": "/mnt/yikes"}
+       }
+    },
+    "globals": {
+        "global0": {
+           "options": {
+             "server min protocol": "SMB1"
+           }
+        }
+    }
+}""",
+            "foobar",
+            False,
+        ),
+    ],
+)
+def test_instance_config_equality(json_a, json_b, iname, expect_equal):
+    gca = sambacc.config.GlobalConfig(io.StringIO(json_a))
+    gcb = sambacc.config.GlobalConfig(io.StringIO(json_b))
+    instance_a = gca.get(iname)
+    instance_b = gcb.get(iname)
+    if expect_equal:
+        assert instance_a == instance_b
+    else:
+        assert instance_a != instance_b

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -49,3 +49,15 @@ def test_ensure_samba_dirs_already(tmp_path):
     os.mkdir(tmp_path / "run/samba/")
     os.mkdir(tmp_path / "run/samba/winbindd")
     sambacc.paths.ensure_samba_dirs(root=tmp_path)
+
+
+def test_ensure_share_dirs(tmp_path):
+    assert not os.path.exists(tmp_path / "foobar")
+    sambacc.paths.ensure_share_dirs("foobar", root=str(tmp_path))
+    assert os.path.exists(tmp_path / "foobar")
+
+    assert not os.path.exists(tmp_path / "wibble")
+    sambacc.paths.ensure_share_dirs("/wibble/cat", root=str(tmp_path))
+    assert os.path.exists(tmp_path / "wibble/cat")
+    sambacc.paths.ensure_share_dirs("/wibble/cat", root=str(tmp_path))
+    assert os.path.exists(tmp_path / "wibble/cat")


### PR DESCRIPTION
Add support for updating the samba configuration. This can be done as a one time action with the command line `samba-container update-config`. The command also has a `--watch` option which causes the command to continuously loop waiting for changes to the configuration and then applying those to the samba/smbd config.

As part of the need to support adding shares to an existing container, this command also creates share dirs that do not already exist. Creating the share dirs is also now available as a `--setup=share_paths` setup step for the `run` subcommand. This is also available as a standalone subcommand `ensure-share-paths`.

A few general fixes and cleanups come along for the ride.