### PR TITLE
Add permissions handling to sambacc

### DIFF
--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -23,6 +23,7 @@ import typing
 
 from sambacc import config
 from sambacc import leader
+from sambacc import permissions
 from sambacc import simple_waiter
 
 _INOTIFY_OK = True
@@ -151,6 +152,35 @@ def best_leader_locator(
     from sambacc import ctdb
 
     return ctdb.CLILeaderLocator()
+
+
+def perms_handler(
+    config: config.PermissionsConfig,
+    path: str,
+) -> permissions.PermissionsHandler:
+    """Fetch and instantiate the appropriate permissions handler for the given
+    configuration.
+    """
+    if config.method == "none":
+        _logger.info("Using no-op permissions handler")
+        return permissions.NoopPermsHandler(
+            path, config.status_xattr, options=config.options
+        )
+    if config.method == "initialize-share-perms":
+        _logger.info("Using initializing posix permissions handler")
+        return permissions.InitPosixPermsHandler(
+            path, config.status_xattr, options=config.options
+        )
+    if config.method == "always-share-perms":
+        _logger.info("Using always-setting posix permissions handler")
+        return permissions.AlwaysPosixPermsHandler(
+            path, config.status_xattr, options=config.options
+        )
+    # fall back to init perms handler
+    _logger.info("Using initializing posix permissions handler")
+    return permissions.InitPosixPermsHandler(
+        path, config.status_xattr, options=config.options
+    )
 
 
 commands = CommandBuilder()

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -34,6 +34,7 @@ from .cli import (
     best_leader_locator,
     best_waiter,
     commands,
+    perms_handler,
     setup_steps,
 )
 
@@ -95,6 +96,8 @@ def _update_config(
                 continue
             _logger.info(f"Ensuring share path: {path}")
             paths.ensure_share_dirs(path)
+            _logger.info(f"Updating permissions if needed: {path}")
+            perms_handler(share.permissions_config(), path).update()
     # update smb config
     if changed:
         _logger.info("Updating samba configuration")

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -24,7 +24,7 @@ import sambacc.nsswitch_loader as nsswitch
 
 from . import config  # noqa: F401
 from . import users  # noqa: F401
-from .cli import commands, setup_steps, Context
+from .cli import commands, perms_handler, setup_steps, Context
 
 
 _logger = logging.getLogger(__name__)
@@ -86,7 +86,8 @@ def ensure_share_paths(ctx: Context) -> None:
             continue
         _logger.info(f"Ensuring share path: {path}")
         paths.ensure_share_dirs(path)
-        # TODO: set proper perms/acls for a "share root"
+        _logger.info(f"Updating permissions if needed: {path}")
+        perms_handler(share.permissions_config(), path).update()
 
 
 _default_setup_steps = [

--- a/sambacc/permissions.py
+++ b/sambacc/permissions.py
@@ -145,7 +145,14 @@ class InitPosixPermsHandler:
         # yeah, this is really simple compared to all the state management
         # stuff.
         path = self._full_path()
-        os.chmod(path, self._mode, follow_symlinks=False)
+        dfd = os.open(path, os.O_DIRECTORY)
+        try:
+            os.fchmod(dfd, self._mode)
+            os.fsync(dfd)
+        except OSError:
+            os.sync()
+        finally:
+            os.close(dfd)
 
     def _timestamp(self) -> str:
         return datetime.datetime.now().strftime("%s")

--- a/sambacc/permissions.py
+++ b/sambacc/permissions.py
@@ -1,0 +1,170 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2022  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from __future__ import annotations
+
+import datetime
+import errno
+import logging
+import os
+import typing
+
+import xattr  # type: ignore
+
+_logger = logging.getLogger(__name__)
+
+
+class PermissionsHandler(typing.Protocol):
+    def has_status(self) -> bool:
+        """Return true if the path has status metadata."""
+        ...  # pragma: no cover
+
+    def status_ok(self) -> bool:
+        """Return true if status is OK (no changes are needed)."""
+        ...  # pragma: no cover
+
+    def update(self) -> None:
+        """Update the permissions as needed."""
+        ...  # pragma: no cover
+
+    def path(self) -> str:
+        """Return the path under consideration."""
+        ...  # pragma: no cover
+
+
+class NoopPermsHandler:
+    def __init__(
+        self,
+        path: str,
+        status_xattr: str,
+        options: typing.Dict[str, str],
+        root: str = "/",
+    ) -> None:
+        self._path = path
+
+    def path(self) -> str:
+        return self._path
+
+    def has_status(self) -> bool:
+        return False
+
+    def status_ok(self) -> bool:
+        return True
+
+    def update(self) -> None:
+        pass
+
+
+class InitPosixPermsHandler:
+    """Initialize posix permissions on a share (directory).
+
+    This handler sets posix permissions only.
+
+    It will only set the permissions when the status xattr does not
+    match the expected prefix value. This prevents it from overwiting
+    permissions that may have been changed intentionally after
+    share initialization.
+    """
+
+    _default_mode = 0o777
+    _default_status_prefix = "v1"
+
+    def __init__(
+        self,
+        path: str,
+        status_xattr: str,
+        options: typing.Dict[str, str],
+        root: str = "/",
+    ) -> None:
+        self._path = path
+        self._root = root
+        self._xattr = status_xattr
+        try:
+            self._mode = int(options["mode"], 8)
+        except KeyError:
+            self._mode = self._default_mode
+        try:
+            self._prefix = options["status_prefix"]
+        except KeyError:
+            self._prefix = self._default_status_prefix
+
+    def path(self) -> str:
+        return self._path
+
+    def _full_path(self) -> str:
+        return os.path.join(self._root, self._path.lstrip("/"))
+
+    def has_status(self):
+        try:
+            self._get_status()
+            return True
+        except KeyError:
+            return False
+
+    def status_ok(self):
+        try:
+            sval = self._get_status()
+        except KeyError:
+            return False
+        curr_prefix = sval.split("/")[0]
+        return curr_prefix == self._prefix
+
+    def update(self):
+        if self.status_ok():
+            return
+        self._set_perms()
+        self._set_status()
+
+    def _get_status(self) -> str:
+        path = self._full_path()
+        _logger.debug("reading xattr %r: %r", self._xattr, path)
+        try:
+            value = xattr.get(path, self._xattr, nofollow=True)
+        except OSError as err:
+            if err.errno == errno.ENODATA:
+                raise KeyError(self._xattr)
+            raise
+        return value.decode("utf8")
+
+    def _set_perms(self) -> None:
+        # yeah, this is really simple compared to all the state management
+        # stuff.
+        path = self._full_path()
+        os.chmod(path, self._mode, follow_symlinks=False)
+
+    def _timestamp(self) -> str:
+        return datetime.datetime.now().strftime("%s")
+
+    def _set_status(self) -> None:
+        # we save the marker prefix followed by a timestamp as a debugging hint
+        ts = self._timestamp()
+        val = f"{self._prefix}/{ts}"
+        path = self._full_path()
+        _logger.debug("setting xattr %r=%r: %r", self._xattr, val, self._path)
+        return xattr.set(path, self._xattr, val, nofollow=True)
+
+
+class AlwaysPosixPermsHandler(InitPosixPermsHandler):
+    """Works like the init handler, but always sets the permissions,
+    even if the status xattr exists and is valid.
+    May be useful for testing and debugging.
+    """
+
+    def update(self):
+        self._set_perms()
+        self._set_status()

--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -11,6 +11,7 @@ RUN yum install \
     python-tox \
     python3-samba \
     python3-wheel \
+    python3-pyxattr \
     samba-common-tools \
     && yum clean all \
     && true

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -58,7 +58,8 @@ config2 = """
     "configs": {
         "updateme":{
           "shares": ["uno", "dos"],
-          "globals": ["global0"]
+          "globals": ["global0"],
+          "permissions": {"method": "none"}
         }
     },
     "shares": {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,7 +63,10 @@ config2 = """
         "share"
       ],
       "globals": ["global0"],
-      "instance_name": "GANDOLPH"
+      "instance_name": "GANDOLPH",
+      "permissions": {
+          "method": "none"
+      }
     }
   },
   "shares": {
@@ -122,6 +125,9 @@ config3 = """
         "valid users": "sambauser",
         "guest ok": "no",
         "force user": "root"
+      },
+      "permissions": {
+          "method": "none"
       }
     }
   },
@@ -714,3 +720,43 @@ def test_instance_config_equality(json_a, json_b, iname, expect_equal):
         assert instance_a == instance_b
     else:
         assert instance_a != instance_b
+
+
+def test_permissions_config_default():
+    c1 = sambacc.config.GlobalConfig(io.StringIO(config1))
+    ic = c1.get("foobar")
+    for share in ic.shares():
+        assert share.permissions_config().method == "none"
+
+
+def test_permissions_config_instance():
+    c2 = sambacc.config.GlobalConfig(io.StringIO(config2))
+    ic = c2.get("foobar")
+    # TODO: improve test to ensure this isn't getting the default.  it does
+    # work as designed based on coverage, but we shouldn't rely on that
+    for share in ic.shares():
+        assert share.permissions_config().method == "none"
+
+
+def test_permissions_config_share():
+    c3 = sambacc.config.GlobalConfig(io.StringIO(config3))
+    ic = c3.get("foobar")
+    # TODO: improve test to ensure this isn't getting the default.  it does
+    # work as designed based on coverage, but we shouldn't rely on that
+    for share in ic.shares():
+        assert share.permissions_config().method == "none"
+
+
+def test_permissions_config_options():
+    pc = sambacc.config.PermissionsConfig(
+        {
+            "method": "initialize-share-perms",
+            "status_xattr": "user.fake-stuff",
+            "mode": "0777",
+            "friendship": "always",
+        }
+    )
+    opts = pc.options
+    assert len(opts) == 2
+    assert "mode" in opts
+    assert "friendship" in opts

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -1,0 +1,97 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2022  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import os
+
+import pytest
+import xattr  # type: ignore
+
+import sambacc.permissions
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [
+        sambacc.permissions.NoopPermsHandler,
+        sambacc.permissions.InitPosixPermsHandler,
+        sambacc.permissions.AlwaysPosixPermsHandler,
+    ],
+)
+def test_permissions_path(cls):
+    assert cls("/foo", "user.foo", options={}).path() == "/foo"
+
+
+def test_noop_handler():
+    nh = sambacc.permissions.NoopPermsHandler("/foo", "user.foo", options={})
+    assert nh.path() == "/foo"
+    assert not nh.has_status()
+    assert nh.status_ok()
+    assert nh.update() is None
+
+
+@pytest.fixture(scope="function")
+def tmp_path_xattrs_ok(tmp_path_factory):
+    tmpp = tmp_path_factory.mktemp("needs_xattrs")
+    try:
+        xattr.set(str(tmpp), "user.deleteme", "1")
+        xattr.remove(str(tmpp), "user.deleteme")
+    except OSError:
+        raise pytest.skip(
+            "temp dir does not support xattrs"
+            " (try changing basetmp to a file system that supports xattrs)"
+        )
+    return tmpp
+
+
+def test_init_handler(tmp_path_xattrs_ok):
+    path = tmp_path_xattrs_ok / "foo"
+    os.mkdir(path)
+    ih = sambacc.permissions.InitPosixPermsHandler(
+        str(path), "user.marker", options={}
+    )
+    assert ih.path().endswith("/foo")
+    assert not ih.has_status()
+    assert not ih.status_ok()
+
+    ih.update()
+    assert ih.has_status()
+    assert ih.status_ok()
+
+    os.chmod(path, 0o755)
+    ih.update()
+    assert (os.stat(path).st_mode & 0o777) == 0o755
+
+
+def test_always_handler(tmp_path_xattrs_ok):
+    path = tmp_path_xattrs_ok / "foo"
+    os.mkdir(path)
+    ih = sambacc.permissions.AlwaysPosixPermsHandler(
+        str(path), "user.marker", options={}
+    )
+    assert ih.path().endswith("/foo")
+    assert not ih.has_status()
+    assert not ih.status_ok()
+
+    ih.update()
+    assert ih.has_status()
+    assert ih.status_ok()
+
+    os.chmod(path, 0o755)
+    assert (os.stat(path).st_mode & 0o777) == 0o755
+    ih.update()
+    assert (os.stat(path).st_mode & 0o777) == 0o777

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py39
+envlist = py39, py3
 isolated_build = True
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     inotify_simple
     black>=21.8b0
     dnspython
+    pyxattr
 commands =
     flake8 sambacc tests
     black --check -v .


### PR DESCRIPTION
These patches add general support for choosing and configuring a "permissions handler". Currently our handlers are very simple and allow setting permissions once, always, or never (none=no-op).

Then, in the code paths recently added to ensure share dirs exist we add lines to invoke the permissions handler. In most scenarios this means that the first time this code is called the permissions will be set. On subsequent calls the code will see the status xattr is set and skip changing the perms. As noted above, this is configurable.