### PR TITLE
More type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ version = "{version}"
 [tool.black]
 line-length = 79
 quiet = true
+
+[tool.mypy]
+disallow_incomplete_defs = true

--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -83,7 +83,7 @@ def create_group(name: str) -> None:
     subprocess.check_call(cmd)
 
 
-def add_group_members(group_name: str, members: typing.List[str]) -> None:
+def add_group_members(group_name: str, members: list[str]) -> None:
     cmd = _group_add_members_cmd(group_name, members)
     _logger.info("Adding group members: %r", cmd)
     subprocess.check_call(cmd)
@@ -95,7 +95,7 @@ def _provision_cmd(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
-) -> typing.List[str]:
+) -> list[str]:
     if not dns_backend:
         dns_backend = "SAMBA_INTERNAL"
     if not domain:
@@ -120,7 +120,7 @@ def _join_cmd(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
-) -> typing.List[str]:
+) -> list[str]:
     if not dns_backend:
         dns_backend = "SAMBA_INTERNAL"
     if not domain:
@@ -143,7 +143,7 @@ def _user_create_cmd(
     password: str,
     surname: typing.Optional[str],
     given_name: typing.Optional[str],
-) -> typing.List[str]:
+) -> list[str]:
     cmd = samba_cmds.sambatool[
         "user",
         "create",
@@ -157,7 +157,7 @@ def _user_create_cmd(
     return cmd
 
 
-def _group_add_cmd(name: str) -> typing.List[str]:
+def _group_add_cmd(name: str) -> list[str]:
     cmd = samba_cmds.sambatool[
         "group",
         "add",
@@ -166,9 +166,7 @@ def _group_add_cmd(name: str) -> typing.List[str]:
     return cmd
 
 
-def _group_add_members_cmd(
-    group_name: str, members: typing.List[str]
-) -> typing.List[str]:
+def _group_add_members_cmd(group_name: str, members: list[str]) -> list[str]:
     cmd = samba_cmds.sambatool[
         "group",
         "addmembers",

--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -118,7 +118,7 @@ class CommandBuilder:
             add_command(subparsers, cmd)
         return parser
 
-    def dict(self) -> typing.Dict[str, Command]:
+    def dict(self) -> dict[str, Command]:
         """Return a dict mapping command names to Command object."""
         return {c.name: c for c in self._commands}
 

--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -39,6 +39,19 @@ class Fail(ValueError):
     pass
 
 
+class Parser(typing.Protocol):
+    def frank(self, x: str) -> str:
+        ...  # pragma: no cover
+
+    def set_defaults(self, **kwargs: typing.Any) -> None:
+        ...  # pragma: no cover
+
+    def add_argument(
+        self, *args: typing.Any, **kwargs: typing.Any
+    ) -> typing.Any:
+        ...  # pragma: no cover
+
+
 Command = namedtuple("Command", "name cmd_func arg_func cmd_help")
 
 

--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -55,9 +55,7 @@ class Parser(typing.Protocol):
 Command = namedtuple("Command", "name cmd_func arg_func cmd_help")
 
 
-def toggle_option(
-    parser: argparse.ArgumentParser, arg: str, dest: str, helpfmt: str
-) -> argparse.ArgumentParser:
+def toggle_option(parser: Parser, arg: str, dest: str, helpfmt: str) -> Parser:
     parser.add_argument(
         arg,
         action="store_true",
@@ -82,7 +80,7 @@ def get_help(cmd: Command) -> str:
     return ""
 
 
-def add_command(subparsers, cmd) -> None:
+def add_command(subparsers: typing.Any, cmd: Command) -> None:
     subparser = subparsers.add_parser(cmd.name, help=get_help(cmd))
     subparser.set_defaults(cfunc=cmd.cmd_func)
     if cmd.arg_func is not None:
@@ -109,7 +107,9 @@ class CommandBuilder:
 
         return _wrapper
 
-    def assemble(self, arg_func=None) -> argparse.ArgumentParser:
+    def assemble(
+        self, arg_func: typing.Callable = None
+    ) -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser()
         if arg_func is not None:
             arg_func(parser)

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -127,7 +127,8 @@ def _exec_if_leader(
                 _logger.info("skipping config update. node not leader")
                 return previous, False
             _logger.info("checking for update. node is leader")
-            return cond_func(current, previous)
+            result = cond_func(current, previous)
+        return result
 
     return _call_if_leader
 

--- a/sambacc/commands/dcmain.py
+++ b/sambacc/commands/dcmain.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import typing
+
 from . import addc
 from .cli import Fail
 from .main import (
@@ -31,7 +33,7 @@ from .main import (
 default_cfunc = addc.summary
 
 
-def main(args=None) -> None:
+def main(args: typing.Optional[typing.Sequence[str]] = None) -> None:
     cli = addc.dccommands.assemble(arg_func=global_args).parse_args(args)
     env_to_cli(cli)
     enable_logging(cli)

--- a/sambacc/commands/dns.py
+++ b/sambacc/commands/dns.py
@@ -97,6 +97,7 @@ def _exec_if_leader(iconfig, update_func):
                 _logger.info("skipping dns update. node not leader")
                 return previous, False
             _logger.info("checking for update. node is leader")
-            return update_func(domain, source, previous)
+            result = update_func(domain, source, previous)
+        return result
 
     return leader_update_func

--- a/sambacc/commands/dns.py
+++ b/sambacc/commands/dns.py
@@ -91,7 +91,7 @@ def _exec_if_leader(iconfig, update_func):
         domain: str,
         source: str,
         previous: typing.Optional[container_dns.HostState] = None,
-    ):
+    ) -> typing.Tuple[typing.Optional[container_dns.HostState], bool]:
         with best_leader_locator(iconfig) as ll:
             if not ll.is_leader():
                 _logger.info("skipping dns update. node not leader")

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -17,6 +17,7 @@
 #
 
 import logging
+import typing
 
 from sambacc import ctdb
 from sambacc import paths
@@ -105,7 +106,9 @@ def setup_step_names():
 
 
 @commands.command(name="init")
-def init_container(ctx: Context, steps=None) -> None:
+def init_container(
+    ctx: Context, steps: typing.Optional[typing.Iterable[str]] = None
+) -> None:
     """Initialize the entire container environment."""
     steps = _default_setup_steps if steps is None else list(steps)
     cmds = setup_steps.dict()

--- a/sambacc/commands/join.py
+++ b/sambacc/commands/join.py
@@ -17,19 +17,27 @@
 #
 
 import sys
+import typing
 
 import sambacc.join as joinutil
 
-from .cli import commands, Context, toggle_option, best_waiter, Fail
+from .cli import (
+    Context,
+    Fail,
+    Parser,
+    best_waiter,
+    commands,
+    toggle_option,
+)
 
 
-def _print_join_error(err) -> None:
+def _print_join_error(err: typing.Any) -> None:
     print(f"ERROR: {err}", file=sys.stderr)
     for suberr in getattr(err, "errors", []):
         print(f"  - {suberr}", file=sys.stderr)
 
 
-def _add_join_sources(joiner, cli) -> None:
+def _add_join_sources(joiner: joinutil.Joiner, cli: typing.Any) -> None:
     if cli.insecure or getattr(cli, "insecure_auto_join", False):
         upass = joinutil.UserPass(cli.username, cli.password)
         joiner.add_source(joinutil.JoinBy.PASSWORD, upass)
@@ -41,7 +49,7 @@ def _add_join_sources(joiner, cli) -> None:
         joiner.add_source(joinutil.JoinBy.INTERACTIVE, upass)
 
 
-def _join_args(parser) -> None:
+def _join_args(parser: Parser) -> None:
     parser.set_defaults(insecure=False, files=True, interactive=True)
     toggle_option(
         parser,
@@ -88,7 +96,7 @@ def join(ctx: Context) -> None:
         raise Fail("failed to join to a domain")
 
 
-def _must_join_args(parser) -> None:
+def _must_join_args(parser: Parser) -> None:
     parser.set_defaults(insecure=False, files=True, wait=True)
     toggle_option(
         parser,

--- a/sambacc/commands/main.py
+++ b/sambacc/commands/main.py
@@ -33,7 +33,7 @@ from . import initialize  # noqa: F401
 from . import join  # noqa: F401
 from . import run  # noqa: F401
 from . import users  # noqa: F401
-from .cli import commands, Fail
+from .cli import commands, Fail, Parser
 
 DEFAULT_CONFIG = "/etc/samba/container/config.json"
 DEFAULT_JOIN_MARKER = "/var/lib/samba/container-join-marker.json"
@@ -41,7 +41,7 @@ DEFAULT_JOIN_MARKER = "/var/lib/samba/container-join-marker.json"
 default_cfunc = config_cmds.print_config
 
 
-def global_args(parser) -> None:
+def global_args(parser: Parser) -> None:
     parser.add_argument(
         "--config",
         action="append",
@@ -101,7 +101,13 @@ def global_args(parser) -> None:
     )
 
 
-def from_env(ns, var, ename, default=None, vtype=str) -> None:
+def from_env(
+    ns: typing.Any,
+    var: str,
+    ename: str,
+    default: typing.Any = None,
+    vtype: typing.Optional[typing.Callable] = str,
+) -> None:
     value = getattr(ns, var, None)
     if not value:
         value = os.environ.get(ename, "")
@@ -123,7 +129,7 @@ def split_paths(value):
     return out
 
 
-def env_to_cli(cli) -> None:
+def env_to_cli(cli: typing.Any) -> None:
     from_env(
         cli,
         "config",
@@ -165,7 +171,7 @@ class CommandContext:
         return self._iconfig
 
 
-def pre_action(cli) -> None:
+def pre_action(cli: typing.Any) -> None:
     """Handle debugging/diagnostic related options before the target
     action of the command is performed.
     """
@@ -177,7 +183,7 @@ def pre_action(cli) -> None:
         samba_cmds.set_global_prefix([cli.samba_command_prefix])
 
 
-def enable_logging(cli) -> None:
+def enable_logging(cli: typing.Any) -> None:
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
     handler = logging.StreamHandler()
@@ -188,14 +194,14 @@ def enable_logging(cli) -> None:
     logger.addHandler(handler)
 
 
-def action_filter(cli) -> typing.Optional[str]:
+def action_filter(cli: typing.Any) -> typing.Optional[str]:
     for path in cli.skip_if_file or []:
         if os.path.exists(path):
             return f"skip-if-file: {path} exists"
     return None
 
 
-def main(args=None) -> None:
+def main(args: typing.Optional[typing.Sequence[str]] = None) -> None:
     cli = commands.assemble(arg_func=global_args).parse_args(args)
     env_to_cli(cli)
     enable_logging(cli)

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -162,7 +162,7 @@ class InstanceConfig:
             raise ValueError("ctdb not supported in configuration")
         return CTDBSambaConfig()
 
-    def ctdb_config(self) -> typing.Dict[str, str]:
+    def ctdb_config(self) -> dict[str, str]:
         """Common configuration of CTDB itself."""
         if not self.with_ctdb:
             return {}

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -40,7 +40,7 @@ ADDC: typing.Final[str] = "addc"
 FEATURES: typing.Final[str] = "instance_features"
 
 
-def read_config_files(fnames) -> GlobalConfig:
+def read_config_files(fnames: list[str]) -> GlobalConfig:
     """Read the global container config from the given filenames.
     At least one of the files from the fnames list must exist and contain
     a valid config. If none of the file names exist an error will be raised.
@@ -68,7 +68,7 @@ def read_config_files(fnames) -> GlobalConfig:
     return gconfig
 
 
-def check_config_data(data) -> dict:
+def check_config_data(data: dict[str, typing.Any]) -> dict[str, typing.Any]:
     """Return the config data or raise a ValueError if the config
     is invalid or incomplete.
     """

--- a/sambacc/container_dns.py
+++ b/sambacc/container_dns.py
@@ -77,7 +77,7 @@ def parse_file(path):
         return parse(fh)
 
 
-def match_target(state: HostState, target_name: str) -> typing.List[HostInfo]:
+def match_target(state: HostState, target_name: str) -> list[HostInfo]:
     return [h for h in state.items if h.target == target_name]
 
 

--- a/sambacc/container_dns.py
+++ b/sambacc/container_dns.py
@@ -81,7 +81,12 @@ def match_target(state: HostState, target_name: str) -> typing.List[HostInfo]:
     return [h for h in state.items if h.target == target_name]
 
 
-def register(domain, hs, prefix=None, target_name: str = EXTERNAL) -> bool:
+def register(
+    domain: str,
+    hs: HostState,
+    prefix: typing.Optional[list[str]] = None,
+    target_name: str = EXTERNAL,
+) -> bool:
     updated = False
     for item in match_target(hs, target_name):
         ip = item.ipv4_addr
@@ -99,7 +104,7 @@ def parse_and_update(
     source: str,
     previous: typing.Optional[HostState] = None,
     target_name: str = EXTERNAL,
-    reg_func=register,
+    reg_func: typing.Callable = register,
 ) -> typing.Tuple[HostState, bool]:
     hs = parse_file(source)
     if previous is not None and hs == previous:

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -109,7 +109,7 @@ def write_ctdb_conf(
 
 
 def ensure_ctdb_nodes(
-    ctdb_nodes: typing.List[str], real_path: str, canon_path: str = CTDB_NODES
+    ctdb_nodes: list[str], real_path: str, canon_path: str = CTDB_NODES
 ) -> None:
     """Ensure a real nodes file exists, containing the specificed content,
     and has a symlink in the proper place for ctdb.
@@ -125,14 +125,14 @@ def ensure_ctdb_nodes(
 
 
 def write_nodes_file(
-    fh: typing.IO, ctdb_nodes: typing.List[str], enc: typing.Callable = str
+    fh: typing.IO, ctdb_nodes: list[str], enc: typing.Callable = str
 ) -> None:
     """Write the ctdb nodes file."""
     for node in ctdb_nodes:
         fh.write(enc(f"{node}\n"))
 
 
-def read_nodes_file(fh: typing.IO) -> typing.List[str]:
+def read_nodes_file(fh: typing.IO) -> list[str]:
     """Read content from an open ctdb nodes file."""
     entries = []
     for line in fh:
@@ -140,7 +140,7 @@ def read_nodes_file(fh: typing.IO) -> typing.List[str]:
     return entries
 
 
-def read_ctdb_nodes(path: str = CTDB_NODES) -> typing.List[str]:
+def read_ctdb_nodes(path: str = CTDB_NODES) -> list[str]:
     """Read the content of the ctdb nodes file."""
     try:
         with open(path, "r") as fh:

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -86,7 +86,7 @@ def ensure_ctdb_conf(
 
 
 def write_ctdb_conf(
-    fh: typing.IO, ctdb_params: typing.Dict, enc: typing.Callable = str
+    fh: typing.IO, ctdb_params: dict, enc: typing.Callable = str
 ) -> None:
     """Write a ctdb.conf style output."""
 

--- a/sambacc/inotify_waiter.py
+++ b/sambacc/inotify_waiter.py
@@ -37,8 +37,11 @@ class INotify:
     print_func = None
 
     def __init__(
-        self, path: str, print_func=None, timeout: typing.Optional[int] = None
-    ):
+        self,
+        path: str,
+        print_func: typing.Optional[typing.Callable] = None,
+        timeout: typing.Optional[int] = None,
+    ) -> None:
         if timeout is not None:
             self.timeout = timeout
         self.print_func = print_func

--- a/sambacc/join.py
+++ b/sambacc/join.py
@@ -70,7 +70,9 @@ class Joiner:
         self.marker = marker
 
     def add_source(
-        self, method: JoinBy, value: typing.Optional[str] = None
+        self,
+        method: JoinBy,
+        value: typing.Optional[typing.Union[str, UserPass]] = None,
     ) -> None:
         if method in {JoinBy.PASSWORD, JoinBy.INTERACTIVE}:
             if not isinstance(value, UserPass):
@@ -82,7 +84,7 @@ class Joiner:
             raise ValueError(f"invalid method: {method}")
         self._sources.append((method, value))
 
-    def join(self, dns_updates=False) -> None:
+    def join(self, dns_updates: bool = False) -> None:
         if not self._sources:
             raise JoinError("no sources for join data")
         errors = []
@@ -108,7 +110,7 @@ class Joiner:
             err.errors = errors
             raise err
 
-    def _read_from(self, path) -> UserPass:
+    def _read_from(self, path: str) -> UserPass:
         try:
             with open(path) as fh:
                 data = json.load(fh)
@@ -126,7 +128,7 @@ class Joiner:
             raise JoinError("invalid file content: invalid password")
         return upass
 
-    def _join(self, upass: UserPass, dns_updates=False) -> None:
+    def _join(self, upass: UserPass, dns_updates: bool = False) -> None:
         args = []
         if not dns_updates:
             args.append("--no-dns-updates")
@@ -171,7 +173,9 @@ class Joiner:
 
 
 def join_when_possible(
-    joiner: Joiner, waiter: Waiter, error_handler=None
+    joiner: Joiner,
+    waiter: Waiter,
+    error_handler: typing.Optional[typing.Callable] = None,
 ) -> None:
     while True:
         if joiner.did_join():

--- a/sambacc/leader.py
+++ b/sambacc/leader.py
@@ -18,6 +18,8 @@
 
 import typing
 
+from sambacc.typelets import ExcType, ExcValue, ExcTraceback
+
 
 class LeaderStatus(typing.Protocol):
     """Fetches information about the current cluster leader."""
@@ -35,5 +37,7 @@ class LeaderLocator(typing.Protocol):
     def __enter__(self) -> LeaderStatus:
         ...
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+    def __exit__(
+        self, exc_type: ExcType, exc_val: ExcValue, exc_tb: ExcTraceback
+    ) -> bool:
         ...

--- a/sambacc/netcmd_loader.py
+++ b/sambacc/netcmd_loader.py
@@ -28,7 +28,7 @@ class LoaderError(Exception):
 
 
 def template_config(
-    fh: typing.IO, iconfig: config.SambaConfig, enc=str
+    fh: typing.IO, iconfig: config.SambaConfig, enc: typing.Callable = str
 ) -> None:
     fh.write(enc("[global]\n"))
     for gkey, gval in iconfig.global_options():
@@ -47,7 +47,7 @@ class NetCmdLoader:
         cmd = list(self._net_conf[args])
         return cmd, subprocess.Popen(cmd, **kwargs)
 
-    def _check(self, cli, proc) -> None:
+    def _check(self, cli: typing.Any, proc: subprocess.Popen) -> None:
         ret = proc.wait()
         if ret != 0:
             raise LoaderError("failed to run {}".format(cli))
@@ -59,14 +59,14 @@ class NetCmdLoader:
         proc.stdin.close()
         self._check(cli, proc)
 
-    def dump(self, out: typing.IO):
+    def dump(self, out: typing.IO) -> None:
         """Dump the current smb config in an smb.conf format.
         Writes the dump to `out`.
         """
         cli, proc = self._cmd("list", stdout=out)
         self._check(cli, proc)
 
-    def _parse_shares(self, fh) -> typing.Iterable[str]:
+    def _parse_shares(self, fh: typing.IO) -> typing.Iterable[str]:
         out = []
         for line in fh.readlines():
             line = line.strip().decode("utf8")

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -22,9 +22,9 @@ import os
 import typing
 
 DebugLevel = typing.Optional[str]
-ArgList = typing.Optional[typing.List[str]]
+ArgList = typing.Optional[list[str]]
 
-_GLOBAL_PREFIX: typing.List[str] = []
+_GLOBAL_PREFIX: list[str] = []
 _GLOBAL_DEBUG: str = ""
 
 
@@ -52,7 +52,7 @@ def _daemon_stdout_opt(daemon: str) -> str:
     return opt
 
 
-def set_global_prefix(lst: typing.List[str]) -> None:
+def set_global_prefix(lst: list[str]) -> None:
     _GLOBAL_PREFIX[:] = lst
 
 
@@ -71,8 +71,8 @@ class CommandArgs:
     """A utility class for building command line commands."""
 
     _name: str
-    args: typing.List[str]
-    cmd_prefix: typing.List[str]
+    args: list[str]
+    cmd_prefix: list[str]
 
     def __init__(self, name: str, args: ArgList = None):
         self._name = name
@@ -82,13 +82,13 @@ class CommandArgs:
     def __getitem__(self, new_value: typing.Any) -> CommandArgs:
         return self.__class__(self._name, args=self.args + _to_args(new_value))
 
-    def raw_args(self) -> typing.List[str]:
+    def raw_args(self) -> list[str]:
         return [self._name] + self.args
 
-    def prefix_args(self) -> typing.List[str]:
+    def prefix_args(self) -> list[str]:
         return list(_GLOBAL_PREFIX) + list(self.cmd_prefix)
 
-    def argv(self) -> typing.List[str]:
+    def argv(self) -> list[str]:
         return self.prefix_args() + self.raw_args()
 
     def __iter__(self) -> typing.Iterator[str]:
@@ -123,14 +123,14 @@ class SambaCommand(CommandArgs):
             debug=self.debug,
         )
 
-    def _debug_args(self, dlvl: str = "--debuglevel={}") -> typing.List[str]:
+    def _debug_args(self, dlvl: str = "--debuglevel={}") -> list[str]:
         if self.debug:
             return [dlvl.format(self.debug)]
         if _GLOBAL_DEBUG:
             return [dlvl.format(_GLOBAL_DEBUG)]
         return []
 
-    def raw_args(self) -> typing.List[str]:
+    def raw_args(self) -> list[str]:
         return [self._name] + self._debug_args() + self.args
 
     def __repr__(self) -> str:

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -61,7 +61,7 @@ def set_global_debug(level: str) -> None:
     _GLOBAL_DEBUG = level
 
 
-def _to_args(value) -> typing.List[str]:
+def _to_args(value: typing.Any) -> list[str]:
     if isinstance(value, str):
         return [value]
     return [str(v) for v in value]
@@ -79,7 +79,7 @@ class CommandArgs:
         self.args = args or []
         self.cmd_prefix = []
 
-    def __getitem__(self, new_value) -> CommandArgs:
+    def __getitem__(self, new_value: typing.Any) -> CommandArgs:
         return self.__class__(self._name, args=self.args + _to_args(new_value))
 
     def raw_args(self) -> typing.List[str]:
@@ -116,7 +116,7 @@ class SambaCommand(CommandArgs):
         super().__init__(name, args)
         self.debug = debug
 
-    def __getitem__(self, new_value) -> SambaCommand:
+    def __getitem__(self, new_value: typing.Any) -> SambaCommand:
         return self.__class__(
             self._name,
             args=self.args + _to_args(new_value),

--- a/sambacc/typelets.py
+++ b/sambacc/typelets.py
@@ -1,0 +1,27 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2022  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+"""typelets defines common-ish type hinting types that are tedious to
+remember/redefine.
+"""
+
+from types import TracebackType
+import typing
+
+ExcType = typing.Optional[typing.Type[BaseException]]
+ExcValue = typing.Optional[BaseException]
+ExcTraceback = typing.Optional[TracebackType]


### PR DESCRIPTION
To improve the type annotations usage in sambacc and hopefully catch more errors early the first step is to enable the option "disallow_incomplete_defs" in mypy. This disallows mixing typed and untyped parameters and return types on a single function call. It does not affect a function that has no annotations at all.

The first set of commits adds annotations to many parts of the code base. Then we enable the option in mypy to enforce it in the future (via pyproject.toml). Finally, we update a few straggling uses of typing.List and typing.Dict to the 'list' and 'dict' equivalents since our minimum version is python3.9.