### PR TITLE
Update base container image to fedora 35

### DIFF
--- a/sambacc/_xattr.py
+++ b/sambacc/_xattr.py
@@ -1,0 +1,78 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2022  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+"""xattr shim module
+
+This module exists to insulate sambacc from the platform xattr module.
+Currently it only support pyxattr. This module can be imported without
+pyxattr (xattr) present. The functions will import the required module
+and raise an ImportError if xattr is not available.
+
+This shim also provides a typed functions for xattr management. This
+could have been accomplished by writing a pyi file for xattr but since
+we need the runtime support we just add new functions.
+"""
+
+
+import pathlib
+import typing
+
+XAttrItem = typing.Union[
+    int,  # an open file descriptor, not wrapped by an object
+    pathlib.Path,  # pathlib path object
+    str,  # basic path string
+    typing.IO,  # an open file descriptor, wrapped by an object
+]
+Namespace = typing.Optional[bytes]
+
+
+def get(
+    item: XAttrItem,
+    name: str,
+    *,
+    nofollow: bool = False,
+    namespace: Namespace = None
+) -> bytes:
+    """Get an xattr from the target item and name.
+    See docs for PyXattr module for details.
+    """
+    import xattr  # type: ignore
+
+    kwargs: dict[str, typing.Any] = {"nofollow": nofollow}
+    if namespace is not None:
+        kwargs["namespace"] = namespace
+    return xattr.get(item, name, **kwargs)
+
+
+def set(
+    item: XAttrItem,
+    name: str,
+    value: str,
+    *,
+    flags: typing.Optional[int] = None,
+    nofollow: bool = False,
+    namespace: Namespace = None
+) -> None:
+    """Set an xattr. See docs for PyXattr module for details."""
+    import xattr  # type: ignore
+
+    kwargs: dict[str, typing.Any] = {"nofollow": nofollow}
+    if flags is not None:
+        kwargs["flags"] = flags
+    if namespace is not None:
+        kwargs["namespace"] = namespace
+    return xattr.set(item, name, value, **kwargs)

--- a/sambacc/permissions.py
+++ b/sambacc/permissions.py
@@ -25,7 +25,8 @@ import logging
 import os
 import typing
 
-import xattr  # type: ignore
+from sambacc import _xattr as xattr
+
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:34
+FROM fedora:35
 
 RUN yum install \
     -y --setopt=install_weak_deps=False \
@@ -12,6 +12,7 @@ RUN yum install \
     python3-samba \
     python3-wheel \
     python3-pyxattr \
+    python3.9 \
     samba-common-tools \
     && yum clean all \
     && true

--- a/tests/container/build.sh
+++ b/tests/container/build.sh
@@ -67,7 +67,7 @@ export NSS_WRAPPER_GROUP=/etc/group
 # Run tox with sitepackages enabled to allow access to system installed samba
 # modules. The container env already provides us control over the env.
 info "running test suite with tox"
-tox --sitepackages
+tox
 
 info "building python package(s)"
 pip -qq install build

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -19,7 +19,7 @@
 import os
 
 import pytest
-import xattr  # type: ignore
+
 
 import sambacc.permissions
 
@@ -46,6 +46,11 @@ def test_noop_handler():
 
 @pytest.fixture(scope="function")
 def tmp_path_xattrs_ok(tmp_path_factory):
+    try:
+        import xattr  # type: ignore
+    except ImportError:
+        pytest.skip("xattr module not available")
+
     tmpp = tmp_path_factory.mktemp("needs_xattrs")
     try:
         xattr.set(str(tmpp), "user.deleteme", "1")

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py39, py3
+envlist = formatting, {py3,py39}-mypy, py3, py39
 isolated_build = True
 
 [testenv]
@@ -11,14 +11,24 @@ passenv =
 deps =
     pytest
     pytest-cov
-    flake8
     mypy
-    inotify_simple
-    black>=21.8b0
     dnspython
-    pyxattr
+    py3: inotify_simple
+    py3: pyxattr
+commands =
+    py.test -v tests --cov=sambacc --cov-report=html {posargs}
+
+[testenv:{py3,py39}-mypy]
+deps =
+    mypy
+    {[testenv]deps}
+commands =
+    mypy sambacc tests
+
+[testenv:formatting]
+deps =
+    flake8
+    black>=21.8b0
 commands =
     flake8 sambacc tests
     black --check -v .
-    mypy sambacc tests
-    py.test -v tests --cov=sambacc --cov-report=html {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ deps =
     py3: pyxattr
 commands =
     py.test -v tests --cov=sambacc --cov-report=html {posargs}
+sitepackages = py3: True
 
 [testenv:{py3,py39}-mypy]
 deps =


### PR DESCRIPTION
Fedora 34 is no longer supported with the recent release of F 36. 
With python 3.9 no longer being the "native" version of python I had to juggle a few things wrt to the tox test environments. We want to continue testing with python 3.9 in case we want to also support centos/rhel 9.
So we end up needing runs specifcically for py39 and some for whatever the system version of python is that can pull in native packaged libs like samba/inotify/xattr/etc.

This work is also a stepping stone to building an RPM so that the samba-container images can be "fully" RPMized and we can have a single source of truth for system python package deps (here in sambacc).