### PR TITLE
Pass global options to provision and join calls

### DIFF
--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -31,6 +31,7 @@ def provision(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
+    options: typing.Optional[typing.Iterable[tuple[str, str]]] = None,
 ) -> None:
     # this function is a direct translation of a previous shell script
     # as samba-tool is based on python libs, this function could possibly
@@ -43,6 +44,7 @@ def provision(
             admin_password=admin_password,
             dns_backend=dns_backend,
             domain=domain,
+            options=options,
         )
     )
     return
@@ -95,6 +97,7 @@ def _provision_cmd(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
+    options: typing.Optional[typing.Iterable[tuple[str, str]]] = None,
 ) -> typing.List[str]:
     if not dns_backend:
         dns_backend = "SAMBA_INTERNAL"
@@ -110,8 +113,12 @@ def _provision_cmd(
         f"--realm={realm}",
         f"--domain={domain}",
         f"--adminpass={admin_password}",
-    ].argv()
-    return cmd
+    ]
+    for okey, oval in options or []:
+        if okey == "netbios name":
+            continue
+        cmd = cmd[f"--option={okey}={oval}"]
+    return cmd.argv()
 
 
 def _join_cmd(

--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -56,6 +56,7 @@ def join(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
+    options: typing.Optional[typing.Iterable[tuple[str, str]]] = None,
 ) -> None:
     _logger.info(f"Joining AD domain: realm={realm}")
     subprocess.check_call(
@@ -64,6 +65,7 @@ def join(
             dcname,
             admin_password=admin_password,
             dns_backend=dns_backend,
+            options=options,
         )
     )
 
@@ -127,6 +129,7 @@ def _join_cmd(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
+    options: typing.Optional[typing.Iterable[tuple[str, str]]] = None,
 ) -> typing.List[str]:
     if not dns_backend:
         dns_backend = "SAMBA_INTERNAL"
@@ -141,8 +144,12 @@ def _join_cmd(
         f"--option=netbios name={dcname}",
         f"--dns-backend={dns_backend}",
         f"--password={admin_password}",
-    ].argv()
-    return cmd
+    ]
+    for okey, oval in options or []:
+        if okey == "netbios name":
+            continue
+        cmd = cmd[f"--option={okey}={oval}"]
+    return cmd.argv()
 
 
 def _user_create_cmd(

--- a/sambacc/commands/addc.py
+++ b/sambacc/commands/addc.py
@@ -86,6 +86,7 @@ def _prep_provision(ctx: Context) -> None:
         domain=domconfig.short_domain,
         dcname=dcname,
         admin_password=domconfig.admin_password,
+        options=ctx.instance_config.global_options(),
     )
 
 
@@ -102,6 +103,7 @@ def _prep_join(ctx: Context) -> None:
         domain=domconfig.short_domain,
         dcname=dcname,
         admin_password=domconfig.admin_password,
+        options=ctx.instance_config.global_options(),
     )
 
 

--- a/tests/test_addc.py
+++ b/tests/test_addc.py
@@ -1,0 +1,147 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2022  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import os
+
+import pytest
+
+
+import sambacc.addc
+
+
+def _fake_samba_tool(path):
+    fake_samba_tool = path / "fake_samba_tool.sh"
+    with open(fake_samba_tool, "w") as fh:
+        fh.write("#!/bin/sh\n")
+        fh.write(f"[ -e {path}/fail ] && exit 1\n")
+        fh.write(f'echo "$@" > {path}/args.out\n')
+        fh.write("exit 0")
+    os.chmod(fake_samba_tool, 0o700)
+    return fake_samba_tool
+
+
+def test_provision(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.provision("FOOBAR.TEST", "quux", "h4ckm3")
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "--realm=FOOBAR.TEST" in result
+    assert "--option=netbios name=quux" in result
+    assert "--dns-backend=SAMBA_INTERNAL" in result
+
+    sambacc.addc.provision(
+        "BARFOO.TEST",
+        "quux",
+        "h4ckm3",
+        options=[
+            ("ldap server require strong auth", "no"),
+            ("dns zone scavenging", "yes"),
+            ("ldap machine suffix", "ou=Machines"),
+            ("netbios name", "flipper"),
+        ],
+    )
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "--realm=BARFOO.TEST" in result
+    assert "--option=netbios name=quux" in result
+    assert "--dns-backend=SAMBA_INTERNAL" in result
+    assert "--option=ldap server require strong auth=no" in result
+    assert "--option=dns zone scavenging=yes" in result
+    assert "--option=ldap machine suffix=ou=Machines" in result
+    assert "--option=netbios name=flipper" not in result
+
+    open(tmp_path / "fail", "w").close()
+    with pytest.raises(Exception):
+        sambacc.addc.provision("FOOBAR.TEST", "quux", "h4ckm3")
+
+
+def test_join(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.join("FOOBAR.TEST", "quux", "h4ckm3")
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "FOOBAR.TEST" in result
+    assert "--option=netbios name=quux" in result
+    assert "--dns-backend=SAMBA_INTERNAL" in result
+
+    sambacc.addc.join(
+        "BARFOO.TEST",
+        "quux",
+        "h4ckm3",
+        options=[
+            ("ldap server require strong auth", "no"),
+            ("dns zone scavenging", "yes"),
+            ("ldap machine suffix", "ou=Machines"),
+            ("netbios name", "flipper"),
+        ],
+    )
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "BARFOO.TEST" in result
+    assert "--option=netbios name=quux" in result
+    assert "--dns-backend=SAMBA_INTERNAL" in result
+    assert "--option=ldap server require strong auth=no" in result
+    assert "--option=dns zone scavenging=yes" in result
+    assert "--option=ldap machine suffix=ou=Machines" in result
+    assert "--option=netbios name=flipper" not in result
+
+
+def test_create_user(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.create_user("fflintstone", "b3dr0ck", "Flintstone", "Fred")
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "user create fflintstone" in result
+    assert "--surname=Flintstone" in result
+    assert "--given-name=Fred" in result
+
+
+def test_create_group(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.create_group("quarry_workers")
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "group add quarry_workers" in result
+
+
+def test_add_group_members(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.add_group_members(
+        "quarry_workers", ["fflintstone", "brubble"]
+    )
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "group addmembers quarry_workers" in result
+    assert "fflintstone,brubble" in result

--- a/tests/test_addc.py
+++ b/tests/test_addc.py
@@ -48,6 +48,8 @@ def test_provision(tmp_path, monkeypatch):
     sambacc.addc.provision("FOOBAR.TEST", "quux", "h4ckm3")
     with open(tmp_path / "args.out") as fh:
         result = fh.read()
+    with pytest.raises(OSError):
+        open(tmp_path / "smb.conf")
     assert "--realm=FOOBAR.TEST" in result
     assert "--option=netbios name=quux" in result
     assert "--dns-backend=SAMBA_INTERNAL" in result
@@ -93,6 +95,8 @@ def test_join(tmp_path, monkeypatch):
     sambacc.addc.join("FOOBAR.TEST", "quux", "h4ckm3")
     with open(tmp_path / "args.out") as fh:
         result = fh.read()
+    with pytest.raises(OSError):
+        open(tmp_path / "smb.conf")
     assert "FOOBAR.TEST" in result
     assert "--option=netbios name=quux" in result
     assert "--dns-backend=SAMBA_INTERNAL" in result


### PR DESCRIPTION
Support taking global options defined in the configuration and passing them onto the samba-tools commands that will generate smb.conf.

Fixes: #43 