### PR TITLE
sambacc: complete type annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,11 @@ quiet = true
 
 [tool.mypy]
 disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = "sambacc.*"
+disallow_untyped_defs = true
+
+[[tool.mypy.overrides]]
+module = "sambacc.commands.*"
+disallow_untyped_defs = false

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -90,8 +90,8 @@ class SambaConfig(typing.Protocol):
 
 
 class GlobalConfig:
-    def __init__(self, source=None):
-        self.data = {}
+    def __init__(self, source: typing.Optional[typing.IO] = None) -> None:
+        self.data: dict[str, typing.Any] = {}
         if source is not None:
             self.load(source)
 

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -58,7 +58,11 @@ def next_state(state: NodeState) -> NodeState:
 
 
 class NodeNotPresent(KeyError):
-    def __init__(self, identity, pnn=None):
+    def __init__(
+        self,
+        identity: typing.Any,
+        pnn: typing.Optional[typing.Union[str, int]] = None,
+    ) -> None:
         super().__init__(identity)
         self.identity = identity
         self.pnn = pnn

--- a/sambacc/inotify_waiter.py
+++ b/sambacc/inotify_waiter.py
@@ -69,7 +69,7 @@ class INotify:
     def wait(self) -> None:
         next(self._wait())
 
-    def _get_events(self):
+    def _get_events(self) -> list[typing.Any]:
         timeout = 1000 * self.timeout
         self._print("waiting {}ms for activity...".format(timeout))
         events = self._inotify.read(timeout=timeout)
@@ -85,7 +85,7 @@ class INotify:
             and ((event.mask & _inotify.flags.CLOSE_WRITE) != 0)
         ]
 
-    def _wait(self):
+    def _wait(self) -> typing.Iterator[None]:
         while True:
             for event in self._get_events():
                 if event is None:

--- a/sambacc/jfile.py
+++ b/sambacc/jfile.py
@@ -21,12 +21,13 @@
 import fcntl
 import json
 import os
+import typing
 
 OPEN_RO = os.O_RDONLY
 OPEN_RW = os.O_CREAT | os.O_RDWR
 
 
-def open(path, flags, mode=0o644):
+def open(path: str, flags: int, mode: int = 0o644) -> typing.IO:
     """A wrapper around open to open JSON files for read or read/write.
     `flags` must be os.open type flags. Use `OPEN_RO` and `OPEN_RW` for
     convenience.
@@ -34,7 +35,9 @@ def open(path, flags, mode=0o644):
     return os.fdopen(os.open(path, flags, mode), "r+")
 
 
-def load(fh, default=None):
+def load(
+    fh: typing.IO, default: typing.Optional[dict[str, typing.Any]] = None
+) -> typing.Any:
     """Similar to json.load, but returns the `default` value if fh refers to an
     empty file. fh must be seekable."""
     if fh.read(4) == "":
@@ -46,7 +49,7 @@ def load(fh, default=None):
     return data
 
 
-def dump(data, fh):
+def dump(data: typing.Any, fh: typing.IO) -> None:
     """Similar to json.dump, but truncates the file before writing in order
     to avoid appending data to the file. fh must be seekable.
     """
@@ -55,6 +58,6 @@ def dump(data, fh):
     json.dump(data, fh)
 
 
-def flock(fh):
+def flock(fh: typing.IO) -> None:
     """A simple wrapper around flock."""
     fcntl.flock(fh.fileno(), fcntl.LOCK_EX)

--- a/sambacc/join.py
+++ b/sambacc/join.py
@@ -29,12 +29,14 @@ _logger = logging.getLogger(__name__)
 
 
 class JoinError(Exception):
-    def __init__(self, v):
+    def __init__(self, v: typing.Any) -> None:
         super().__init__(v)
-        self.errors = []
+        self.errors: list[typing.Any] = []
 
 
 _PROMPT = object()
+_PT = typing.TypeVar("_PT")
+_PW = typing.Union[str, _PT]
 
 
 class JoinBy(enum.Enum):
@@ -47,9 +49,13 @@ class UserPass:
     """Encapsulate a username/password pair."""
 
     username: str = "Administrator"
-    password: typing.Optional[str] = None
+    password: typing.Optional[_PW] = None
 
-    def __init__(self, username=None, password=None):
+    def __init__(
+        self,
+        username: typing.Optional[str] = None,
+        password: typing.Optional[_PW] = None,
+    ) -> None:
         if username is not None:
             self.username = username
         if password is not None:
@@ -65,8 +71,8 @@ class Joiner:
 
     _net_ads_join = samba_cmds.net["ads", "join"]
 
-    def __init__(self, marker=None):
-        self._sources = []
+    def __init__(self, marker: typing.Optional[str] = None) -> None:
+        self._sources: list[tuple[JoinBy, typing.Any]] = []
         self.marker = marker
 
     def add_source(

--- a/sambacc/netcmd_loader.py
+++ b/sambacc/netcmd_loader.py
@@ -43,7 +43,9 @@ def template_config(
 class NetCmdLoader:
     _net_conf = samba_cmds.net["conf"]
 
-    def _cmd(self, *args, **kwargs):
+    def _cmd(
+        self, *args: str, **kwargs: typing.Any
+    ) -> tuple[list[str], typing.Any]:
         cmd = list(self._net_conf[args])
         return cmd, subprocess.Popen(cmd, **kwargs)
 

--- a/sambacc/nsswitch_loader.py
+++ b/sambacc/nsswitch_loader.py
@@ -22,10 +22,10 @@ from .textfile import TextFileLoader
 
 
 class NameServiceSwitchLoader(TextFileLoader):
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         super().__init__(path)
-        self.lines = []
-        self.idx = {}
+        self.lines: list[str] = []
+        self.idx: dict[str, int] = {}
 
     def loadlines(self, lines: typing.Iterable[str]) -> None:
         """Load in the lines from the text source."""

--- a/sambacc/passdb_loader.py
+++ b/sambacc/passdb_loader.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import typing
+
 from sambacc import config
 
 # Do the samba python bindings not export any useful constants?
@@ -24,7 +26,7 @@ ACB_NORMAL = 0x00000010
 ACB_PWNOEXP = 0x00000200
 
 
-def _samba_modules():
+def _samba_modules() -> tuple[typing.Any, typing.Any]:
     from samba.samba3 import param  # type: ignore
     from samba.samba3 import passdb  # type: ignore
 
@@ -32,7 +34,7 @@ def _samba_modules():
 
 
 class PassDBLoader:
-    def __init__(self, smbconf=None):
+    def __init__(self, smbconf: typing.Any = None) -> None:
         param, passdb = _samba_modules()
         lp = param.get_context()
         if smbconf is None:

--- a/sambacc/passwd_loader.py
+++ b/sambacc/passwd_loader.py
@@ -23,9 +23,9 @@ from sambacc import config
 
 
 class LineFileLoader(TextFileLoader):
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         super().__init__(path)
-        self.lines = []
+        self.lines: list[str] = []
 
     def loadlines(self, lines: typing.Iterable[str]) -> None:
         """Load in the lines from the text source."""
@@ -43,9 +43,9 @@ class LineFileLoader(TextFileLoader):
 
 
 class PasswdFileLoader(LineFileLoader):
-    def __init__(self, path="/etc/passwd"):
+    def __init__(self, path: str = "/etc/passwd") -> None:
         super().__init__(path)
-        self._usernames = set()
+        self._usernames: set[str] = set()
 
     def readfp(self, fp: typing.IO) -> None:
         super().readfp(fp)
@@ -66,9 +66,9 @@ class PasswdFileLoader(LineFileLoader):
 
 
 class GroupFileLoader(LineFileLoader):
-    def __init__(self, path="/etc/group"):
+    def __init__(self, path: str = "/etc/group") -> None:
         super().__init__(path)
-        self._groupnames = set()
+        self._groupnames: set[str] = set()
 
     def readfp(self, fp: typing.IO) -> None:
         super().readfp(fp)

--- a/sambacc/permissions.py
+++ b/sambacc/permissions.py
@@ -124,14 +124,14 @@ class InitPosixPermsHandler:
     def _full_path(self) -> str:
         return os.path.join(self._root, self._path.lstrip("/"))
 
-    def has_status(self):
+    def has_status(self) -> bool:
         try:
             self._get_status()
             return True
         except KeyError:
             return False
 
-    def status_ok(self):
+    def status_ok(self) -> bool:
         try:
             sval = self._get_status()
         except KeyError:
@@ -139,7 +139,7 @@ class InitPosixPermsHandler:
         curr_prefix = sval.split("/")[0]
         return curr_prefix == self._prefix
 
-    def update(self):
+    def update(self) -> None:
         if self.status_ok():
             return
         self._set_perms()
@@ -182,6 +182,6 @@ class AlwaysPosixPermsHandler(InitPosixPermsHandler):
     May be useful for testing and debugging.
     """
 
-    def update(self):
+    def update(self) -> None:
         self._set_perms()
         self._set_status()

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -159,19 +159,19 @@ winbindd = SambaCommand("/usr/sbin/winbindd")
 samba_dc = SambaCommand("/usr/sbin/samba")
 
 
-def smbd_foreground():
+def smbd_foreground() -> SambaCommand:
     return smbd[
         "--foreground", _daemon_stdout_opt("smbd"), "--no-process-group"
     ]
 
 
-def winbindd_foreground():
+def winbindd_foreground() -> SambaCommand:
     return winbindd[
         "--foreground", _daemon_stdout_opt("winbindd"), "--no-process-group"
     ]
 
 
-def samba_dc_foreground():
+def samba_dc_foreground() -> SambaCommand:
     return samba_dc["--foreground"]
 
 

--- a/sambacc/simple_waiter.py
+++ b/sambacc/simple_waiter.py
@@ -20,7 +20,7 @@ import time
 import typing
 
 
-def generate_sleeps():
+def generate_sleeps() -> typing.Iterator[int]:
     """Generate sleep times starting with short sleeps and then
     getting longer. This assumes that resources may take a bit of
     time to settle, but eventually reach a steadier state and don't
@@ -44,16 +44,18 @@ def generate_sleeps():
 class Sleeper:
     """It waits only by sleeping. Nothing fancy."""
 
-    def __init__(self, times=None):
+    def __init__(
+        self, times: typing.Optional[typing.Iterator[int]] = None
+    ) -> None:
         if times is None:
             times = generate_sleeps()
         self._times = times
         self._sleep = time.sleep
 
-    def wait(self):
+    def wait(self) -> None:
         self._sleep(next(self._times))
 
-    def acted(self):
+    def acted(self) -> None:
         """Inform the sleeper the caller reacted to a change and
         the sleeps should be reset.
         """

--- a/tests/test_container_dns.py
+++ b/tests/test_container_dns.py
@@ -201,6 +201,7 @@ def test_watch(tmp_path):
         path,
         update_func=_update,
         pause_func=_sleep,
+        print_func=lambda x: None,
     )
     assert scount > 10
     assert len(reg_data) == 1
@@ -227,6 +228,7 @@ def test_watch(tmp_path):
         path,
         update_func=_update,
         pause_func=_sleep2,
+        print_func=lambda x: None,
     )
     assert scount > 20
     assert len(reg_data) == 3


### PR DESCRIPTION
The sambacc dir is basically a library and we want to ensure high quality and good documentation so configure mypy to require
type annotations on functions defined in sambacc. Update code in sambacc to add type annotations to any functions lacking them.

The sambacc.commands on the other hand are mean to be only run as part of our CLI tools so we'll be a bit less strict there.