### PR TITLE
container: bump base image to fedora36

### DIFF
--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,4 +1,4 @@
-FROM fedora:35
+FROM registry.fedoraproject.org/fedora:36
 
 RUN yum install \
     -y --setopt=install_weak_deps=False \


### PR DESCRIPTION
Expects Fedora36 to be maintained until mid 2023.
Use full image name, same as in 'samba-container' images.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>