### PR TITLE
Use newly replaced `leader` admin command for `ctdb`

### DIFF
--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -527,8 +527,9 @@ class CLILeaderLocator:
             _logger.error(f"command {pnn_cmd!r} failed: {err!r}")
         except FileNotFoundError:
             _logger.error(f"ctdb command ({pnn_cmd!r}) not found")
-        # recmaster = <ctdb recmaster>
-        recmaster_cmd = samba_cmds.ctdb["recmaster"]
+        # recmaster = <ctdb recmaster|leader>
+        admin_cmd = samba_cmds.ctdb_leader_admin_cmd()
+        recmaster_cmd = samba_cmds.ctdb[admin_cmd]
         try:
             out = subprocess.check_output(list(recmaster_cmd))
             recmaster = out.decode("utf8").strip()

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -30,6 +30,7 @@ _GLOBAL_DEBUG: str = ""
 
 # Known flags for SAMBA_SPECIFICS env variable
 _DAEMON_CLI_STDOUT_OPT: str = "daemon_cli_debug_output"
+_CTDB_LEADER_ADMIN_CMD: str = "ctdb_leader_admin_command"
 
 
 def get_samba_specifics() -> typing.Set[str]:
@@ -50,6 +51,14 @@ def _daemon_stdout_opt(daemon: str) -> str:
     if _DAEMON_CLI_STDOUT_OPT in opt_lst:
         opt = "--debug-stdout"
     return opt
+
+
+def ctdb_leader_admin_cmd() -> str:
+    leader_cmd = "recmaster"
+    opt_lst = get_samba_specifics()
+    if _CTDB_LEADER_ADMIN_CMD in opt_lst:
+        leader_cmd = "leader"
+    return leader_cmd
 
 
 def set_global_prefix(lst: list[str]) -> None:


### PR DESCRIPTION
With Samba [v4.16](https://www.samba.org/samba/history/samba-4.16.0.html), `recmaster` administrative sub-command for `ctdb` was renamed to `leader`. Therefore we make use of already existing mechanism to detect the presence of `leader` admin command and execute it for determining the leader node.