### PR TITLE
tox.ini: avoid one tox warning when running py3-mypy

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,13 +11,9 @@ passenv =
 deps =
     pytest
     pytest-cov
-    mypy
     dnspython
-    py3: inotify_simple
-    py3: pyxattr
 commands =
     py.test -v tests --cov=sambacc --cov-report=html {posargs}
-sitepackages = py3: True
 
 [testenv:{py3,py39}-mypy]
 deps =
@@ -25,6 +21,20 @@ deps =
     {[testenv]deps}
 commands =
     mypy sambacc tests
+
+[testenv:py3]
+# In order to run tests that rely on "system level" packages (samba,
+# xattr, etc.), and not have a lot of test skips, we have to enable the
+# sitepackages option. However when it is enabled and you already have a tool
+# (mypy, pytest, etc.) installed at the system tox emits a `command found but
+# not installed in testenv` warning. We can avoid all those warnings except for
+# the 'py3' env by putting all that system enablement stuff only in this
+# section.
+sitepackages = True
+deps =
+    inotify_simple
+    pyxattr
+    {[testenv]deps}
 
 [testenv:formatting]
 deps =


### PR DESCRIPTION
Rework how the tox.ini file is organized in order to remove a `command found but not installed in testenv` when running tox. We currently need at least one test run to be executed with system site packages enabled, but we don't need it that way for mypy.
