### PR TITLE
sambacc: re-format with black version 23.1a1

### DIFF
--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -116,6 +116,7 @@ def _exec_if_leader(
     cond_func: typing.Callable[..., typing.Tuple[config.InstanceConfig, bool]],
 ) -> typing.Callable[..., typing.Tuple[config.InstanceConfig, bool]]:
     """Run the cond func only on "nodes" that are the cluster leader."""
+
     # CTDB status and leader detection is not changeable at runtime.
     # we do not need to account for it changing in the updated config file(s)
     @functools.wraps(cond_func)


### PR DESCRIPTION
Latest black version (23.1a1) requires extra empty line after one-liner comment. This, in turn, causes samba-container CI to fail.

Signed-off-by: Shachar Sharon <ssharon@redhat.com>