### PR TITLE
container: self contained build script

### DIFF
--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,30 +1,14 @@
-FROM registry.fedoraproject.org/fedora:36
+ARG SAMBACC_BASE_IMAGE='registry.fedoraproject.org/fedora:36'
+FROM $SAMBACC_BASE_IMAGE
 
-RUN yum install \
-    -y --setopt=install_weak_deps=False \
-    git \
-    mercurial \
-    python-pip \
-    python-pip-wheel \
-    python-setuptools \
-    python-setuptools-wheel \
-    python-tox \
-    python3-samba \
-    python3-wheel \
-    python3-pyxattr \
-    python3-devel \
-    python3.9 \
-    samba-common-tools \
-    rpm-build \
-    'python3dist(flake8)' \
-    'python3dist(inotify-simple)' \
-    'python3dist(mypy)' \
-    'python3dist(pytest)' \
-    'python3dist(pytest-cov)' \
-    'python3dist(setuptools-scm)' \
-    'python3dist(tox-current-env)' \
-    'python3dist(wheel)' \
-    && yum clean all \
-    && true
+
 COPY build.sh /usr/local/bin/build.sh
+
+# Set SAMBACC_MINIMAL to yes to build a container that only contains the
+# build.sh script on top of the base image. When called, build.sh will
+# automatically install the dependency packages. Installing packages on every
+# run can be slow, especially if you are hacking on the code or tests, so we
+# install those dependencies proactively by default.
+ARG SAMBACC_MINIMAL=no
+RUN if [ "$SAMBACC_MINIMAL" != "yes" ]; then /usr/local/bin/build.sh --install ; fi
 ENTRYPOINT ["/usr/local/bin/build.sh"]


### PR DESCRIPTION
Right now, sambacc and samba-containers is in a pretty awkward situation. The base oses for the images are different and we're building RPMs that have the wrong ABI for the samba-container images. 

These changes pull nearly all the logic out of the continerfile and into build.sh so that it is easier to build and test and varying base OSes. If this is merged we have the ability to create multi-stage builds in samba-containers project hat pretty much only need to consume sambacc's container image OR even simply drop that and do something like curl build.sh from sambacc's github repo. Regardless of how we use it in the samba-containers repo I think this is helpful step to get out of a bad sitation and gain flexibility when executing tests.

----

This now makes it possible to more easily test and reuse the sambacc
test (and build) container image for different base OSes. For example:

```
podman build -t sambacc:mini36 --build-arg=SAMBACC_BASE_IMAGE=registry.fedoraproject.org/fedora:36 --build-arg=SAMBACC_MINIMAL=yes -f tests/container/Containerfile
podman run --rm -it sambacc:mini36

podman build -t sambacc:c9s -f tests/container/Containerfile

podman build -t sambacc:mini9 --build-arg=SAMBACC_MINIMAL=yes -f tests/container/Containerfile

podman build -t sambacc:fc37 --build-arg=SAMBACC_BASE_IMAGE=registry.fedoraproject.org/fedora:37 -f tests/container/Containerfile
```