### PR TITLE
Correct smbd log option

### DIFF
--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -44,7 +44,7 @@ def get_samba_specifics() -> typing.Set[str]:
 
 def _daemon_stdout_opt(daemon: str) -> str:
     if daemon == "smbd":
-        opt = "--log-stdout"
+        opt = "--debug-stdout"
     else:
         opt = "--stdout"
     opt_lst = get_samba_specifics()


### PR DESCRIPTION
The samba-containers `make test` is failing
because smbd can't start when passed an invalid
parameter. The parameter should be
`--debug-stdout`, not `--log-stdout`.

Signed-off-by: David Mulder <dmulder@samba.org>