### PR TITLE
Revert "container: Switch to CentOS Stream 9 as base image"

### DIFF
--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,8 +1,6 @@
-FROM quay.io/centos/centos:stream9
+FROM registry.fedoraproject.org/fedora:36
 
-RUN yum install -y epel-release
-
-RUN yum --enablerepo=crb install \
+RUN yum install \
     -y --setopt=install_weak_deps=False \
     git \
     mercurial \
@@ -18,7 +16,6 @@ RUN yum --enablerepo=crb install \
     python3.9 \
     samba-common-tools \
     rpm-build \
-    pyproject-rpm-macros \
     'python3dist(flake8)' \
     'python3dist(inotify-simple)' \
     'python3dist(mypy)' \


### PR DESCRIPTION
This reverts commit af63900e4a0f2cef025656a7242c2cdda73fc845.

This should fix the current failures in samba-containers, allowing us to have a more in-depth discussion of what the right way forward is.

Signed-off-by: John Mulligan <jmulligan@redhat.com>