### PR TITLE
docs: fix incorrect version number in configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,7 +140,7 @@ structure and a description of these sections.
 
 Every valid sambacc JSON configuration file contains the key
 `samba-container-config` with a value in the form of a string vN were
-N is the numeric version number. Currently, only "v1" exists.
+N is the numeric version number. Currently, only "v0" exists.
 This key-value combination allows us to support backwards-incompatible
 configuration file format changes in the future.
 


### PR DESCRIPTION
Fix the  version given for the samba-container-config key. The code and examples were correct but the docs had "v1" was was an error I made when first writing the doc.

Fixes: #66 