### PR TITLE
Add json schema support for validating the configuration

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 # Include example files
 recursive-include examples *
+recursive-include sambacc/schema *.json *.yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,3 +28,7 @@ disallow_untyped_defs = true
 [[tool.mypy.overrides]]
 module = "sambacc.commands.*"
 disallow_untyped_defs = false
+
+[[tool.mypy.overrides]]
+module = "sambacc.schema.*"
+disallow_untyped_defs = false

--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -141,6 +141,10 @@ class Context(typing.Protocol):
     def instance_config(self) -> config.InstanceConfig:
         ...  # pragma: no cover
 
+    @property
+    def require_validation(self) -> typing.Optional[bool]:
+        ...  # pragma: no cover
+
 
 def best_waiter(
     filename: typing.Optional[str] = None,

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -72,7 +72,9 @@ def _update_config_args(parser: argparse.ArgumentParser) -> None:
 
 def _read_config(ctx: Context) -> config.InstanceConfig:
     cfgs = ctx.cli.config or []
-    return config.read_config_files(cfgs).get(ctx.cli.identity)
+    return config.read_config_files(
+        cfgs, require_validation=ctx.require_validation
+    ).get(ctx.cli.identity)
 
 
 def _update_config(

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -95,8 +95,13 @@ class SambaConfig(typing.Protocol):
 
 
 class GlobalConfig:
-    def __init__(self, source: typing.Optional[typing.IO] = None) -> None:
-        self.data: JSONData = {}
+    def __init__(
+        self,
+        source: typing.Optional[typing.IO] = None,
+        *,
+        initial_data: typing.Optional[JSONData] = None,
+    ) -> None:
+        self.data: JSONData = {} if initial_data is None else initial_data
         if source is not None:
             self.load(source)
 

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -32,6 +32,11 @@ _open = open
 PasswdEntryTuple = typing.Tuple[str, str, str, str, str, str, str]
 GroupEntryTuple = typing.Tuple[str, str, str, str]
 
+# JSONData is not really a completely valid representation of json in
+# the type system, but it's good enough for now. Using it can help
+# clarify what works with json and what works with real python dicts.
+JSONData = dict[str, typing.Any]
+
 # the standard location for samba's smb.conf
 SMB_CONF = "/etc/samba/smb.conf"
 
@@ -68,7 +73,7 @@ def read_config_files(fnames: list[str]) -> GlobalConfig:
     return gconfig
 
 
-def _check_config_data(data: dict[str, typing.Any]) -> dict[str, typing.Any]:
+def _check_config_data(data: JSONData) -> JSONData:
     """Return the config data or raise a ValueError if the config
     is invalid or incomplete.
     """
@@ -91,7 +96,7 @@ class SambaConfig(typing.Protocol):
 
 class GlobalConfig:
     def __init__(self, source: typing.Optional[typing.IO] = None) -> None:
-        self.data: dict[str, typing.Any] = {}
+        self.data: JSONData = {}
         if source is not None:
             self.load(source)
 

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -64,11 +64,11 @@ def read_config_files(fnames: list[str]) -> GlobalConfig:
         # we read nothing! don't proceed
         raise ValueError(f"None of the config file paths exist: {fnames}")
     # Verify that we loaded something
-    check_config_data(gconfig.data)
+    _check_config_data(gconfig.data)
     return gconfig
 
 
-def check_config_data(data: dict[str, typing.Any]) -> dict[str, typing.Any]:
+def _check_config_data(data: dict[str, typing.Any]) -> dict[str, typing.Any]:
     """Return the config data or raise a ValueError if the config
     is invalid or incomplete.
     """
@@ -96,7 +96,7 @@ class GlobalConfig:
             self.load(source)
 
     def load(self, source: typing.IO) -> None:
-        data = check_config_data(json.load(source))
+        data = _check_config_data(json.load(source))
         self.data.update(data)
 
     def get(self, ident: str) -> InstanceConfig:

--- a/sambacc/schema/conf-v0.schema.json
+++ b/sambacc/schema/conf-v0.schema.json
@@ -1,0 +1,303 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "mailto:phlogistonjohn+sambacc-v0@asynchrono.us",
+  "title": "sambacc configuration",
+  "description": "The configuration for the sambacc tool. sambacc configures Samba and the container\nenvironment to fit Samba's unique needs. This configuration can hold configuration\nfor more than one server \"instance\". The \"configs\" section contains one or more\nconfiguration with a name that can be selected at runtime. Share definitions\nand samba global configuration blocks can be mixed and matched.\n",
+  "type": "object",
+  "$defs": {
+    "section_choices": {
+      "description": "Selects sub-sections from elsewhere in the configuration.\n",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "feature_flags": {
+      "description": "Feature flags are used to enable specific, wide-ranging, features of\nsambacc. For example, it is used to enable clustered mode with ctdb.\n",
+      "type": "array",
+      "items": {
+        "enum": [
+          "addc",
+          "ctdb"
+        ]
+      }
+    },
+    "samba_options": {
+      "description": "A mapping of values that will be passed into the smb.conf (or equivalent)\nto directly configure Samba.\n",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "permissions_config": {
+      "description": "Settings that enable and manage sambacc's permissions management support.\n",
+      "type": "object",
+      "properties": {
+        "method": {
+          "description": "Backend method for controlling permissions on shares",
+          "type": "string"
+        },
+        "status_xattr": {
+          "description": "xattr name used to store permissions state",
+          "type": "string"
+        }
+      },
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "user_entry": {
+      "description": "A user that will be instantiated in the local contianer environment to\nin order to provide access to smb shares.\n",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The user's name",
+          "type": "string"
+        },
+        "uid": {
+          "description": "The Unix UID the user should have",
+          "type": "integer"
+        },
+        "gid": {
+          "description": "The Unix GID the user should have",
+          "type": "integer"
+        },
+        "nt_hash": {
+          "description": "An NT-Hashed password",
+          "type": "string"
+        },
+        "password": {
+          "description": "A plain-text password",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "group_entry": {
+      "description": "A group that will be instantiated in the local contianer environment to\nin order to provide access to smb shares.\n",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The group name",
+          "type": "string"
+        },
+        "gid": {
+          "description": "The Unix GID the group should have",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "domain_user_entry": {
+      "description": "A user that will be created in the specified AD domain. These\nusers are populated in the directory after the domain is provisioned.\n",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The user's name",
+          "type": "string"
+        },
+        "surname": {
+          "description": "A surname for the user",
+          "type": "string"
+        },
+        "given_name": {
+          "description": "A given name for the user",
+          "type": "string"
+        },
+        "uid": {
+          "type": "integer"
+        },
+        "gid": {
+          "type": "integer"
+        },
+        "nt_hash": {
+          "type": "string"
+        },
+        "password": {
+          "description": "A plain-text password",
+          "type": "string"
+        },
+        "member_of": {
+          "description": "A list of group names that the user should belong to",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "domain_group_entry": {
+      "description": "A group that will be created in the specified AD domain. These\ngroups are populated in the directory after the domain is provisioned.\n",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The group name",
+          "type": "string"
+        },
+        "gid": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "samba-container-config": {
+      "type": "string",
+      "title": "Cofiguration Format Version",
+      "description": "A short version string that assists in allowing the configuration\nformat to (some day) support incompatible version changes.\n(It is unique to the configuration and is not the version of sambacc)\n"
+    },
+    "configs": {
+      "title": "Container Configurations",
+      "description": "A mapping of named configurations (instances) to top-level configuration\nblocks. A useable configuration file must have at least one configuration,\nbut more than one is supported.\n",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "shares": {
+            "$ref": "#/$defs/section_choices"
+          },
+          "globals": {
+            "$ref": "#/$defs/section_choices"
+          },
+          "instance_features": {
+            "$ref": "#/$defs/feature_flags"
+          },
+          "permissions": {
+            "$ref": "#/$defs/permissions_config"
+          },
+          "instance_name": {
+            "description": "A name that will be set for the server instance.\n",
+            "type": "string"
+          },
+          "domain_settings": {
+            "description": "The name of the domain settings. Only used with 'ADDC' feature flag.\n",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "shares": {
+      "description": "A mapping of share name to share specific configuration. A share can\nhave \"options\" that are passed to Samba. Shares can have an optional\n\"permissions\" section for managing permissions/acls in sambacc.\n",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "options": {
+            "$ref": "#/$defs/samba_options"
+          },
+          "permissions": {
+            "$ref": "#/$defs/permissions_config"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "globals": {
+      "description": "A mapping of samba global configuation blocks. The global section names\nare not passed to Samba. All sections selected by a configuration are\nmerged together before passing to Samba.\n",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "options": {
+            "$ref": "#/$defs/samba_options"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "domain_settings": {
+      "description": "A mapping of AD DC domain configuration keys to domain configurations.\nThese parameters are used when provisioning an AD DC instance.\n",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "realm": {
+            "type": "string"
+          },
+          "short_domain": {
+            "type": "string"
+          },
+          "admin_password": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "realm"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "users": {
+      "description": "Users to add to the container environment in order to provide\nShare access-control wihout becoming a domain member server.\n",
+      "type": "object",
+      "properties": {
+        "all_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/user_entry"
+          }
+        }
+      }
+    },
+    "groups": {
+      "description": "Groups to add to the container environment in order to provide\nShare access-control wihout becoming a domain member server.\n",
+      "type": "object",
+      "properties": {
+        "all_entries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/group_entry"
+          }
+        }
+      }
+    },
+    "domain_users": {
+      "description": "The domain_users section defines initial users that will be automatically\nadded to a newly provisioned domain. This section is a mapping of the\ndomain settings name to a list of domain user entries.\n",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/domain_user_entry"
+        }
+      }
+    },
+    "domain_groups": {
+      "description": "The domain_groups section defines initial groups that will be\nautomatically added to a newly provisioned domain. This section is\na mapping of the domain settings name to a list of domain group entries.\n",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/$defs/domain_group_entry"
+        }
+      }
+    },
+    "ctdb": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "samba-container-config"
+  ],
+  "patternProperties": {
+    "^_": true
+  }
+}

--- a/sambacc/schema/conf-v0.schema.yaml
+++ b/sambacc/schema/conf-v0.schema.yaml
@@ -1,0 +1,296 @@
+---
+# EDIT THIS FILE
+# When you are done editing this YAML representation, convert it into
+# a matching <name>.json file in the same directory. That file exists
+# for jsonschema implmenations that can't read directly from YAML.
+#
+# After edting this file, generated files need to be updated.
+# Run: python -m sambacc.schema.tool --update
+#
+$schema:  "http://json-schema.org/draft-07/schema#"
+$id: "mailto:phlogistonjohn+sambacc-v0@asynchrono.us"
+title: "sambacc configuration"
+description: |
+  The configuration for the sambacc tool. sambacc configures Samba and the container
+  environment to fit Samba's unique needs. This configuration can hold configuration
+  for more than one server "instance". The "configs" section contains one or more
+  configuration with a name that can be selected at runtime. Share definitions
+  and samba global configuration blocks can be mixed and matched.
+type: "object"
+$defs:
+  # indirections from the configuration to named sections
+  # under globals, shares, etc.
+  section_choices:
+    description: |
+      Selects sub-sections from elsewhere in the configuration.
+    type: array
+    items:
+      type: string
+  # feature flags are a known set of values
+  feature_flags:
+    description: |
+      Feature flags are used to enable specific, wide-ranging, features of
+      sambacc. For example, it is used to enable clustered mode with ctdb.
+    type: array
+    items:
+      enum:
+        - addc
+        - ctdb
+  # options that are passed directly into smb.conf
+  samba_options:
+    description: |
+      A mapping of values that will be passed into the smb.conf (or equivalent)
+      to directly configure Samba.
+    type: object
+    additionalProperties:
+      type: string
+  # permissions backend configurations
+  # each backend may have it's own set of additional properties
+  permissions_config:
+    description: |
+      Settings that enable and manage sambacc's permissions management support.
+    type: object
+    properties:
+      method:
+        description: Backend method for controlling permissions on shares
+        type: string
+      status_xattr:
+        description: xattr name used to store permissions state
+        type: string
+    additionalProperties:
+      type: string
+  # file server user entries
+  user_entry:
+    description: |
+      A user that will be instantiated in the local contianer environment to
+      in order to provide access to smb shares.
+    type: object
+    properties:
+      name:
+        description: The user's name
+        type: string
+      uid:
+        description: The Unix UID the user should have
+        type: integer
+      gid:
+        description: The Unix GID the user should have
+        type: integer
+      nt_hash:
+        description: An NT-Hashed password
+        type: string
+      password:
+        description: A plain-text password
+        type: string
+    required:
+      - name
+    additionalProperties: false
+  # file server group entries
+  group_entry:
+    description: |
+      A group that will be instantiated in the local contianer environment to
+      in order to provide access to smb shares.
+    type: object
+    properties:
+      name:
+        description: The group name
+        type: string
+      gid:
+        description: The Unix GID the group should have
+        type: integer
+    required:
+      - name
+    additionalProperties: false
+  # domain controller user entries
+  domain_user_entry:
+    description: |
+      A user that will be created in the specified AD domain. These
+      users are populated in the directory after the domain is provisioned.
+    type: object
+    properties:
+      name:
+        description: The user's name
+        type: string
+      surname:
+        description: A surname for the user
+        type: string
+      given_name:
+        description: A given name for the user
+        type: string
+      uid:
+        type: integer
+      gid:
+        type: integer
+      nt_hash:
+        type: string
+      password:
+        description: A plain-text password
+        type: string
+      member_of:
+        description: A list of group names that the user should belong to
+        type: array
+        items:
+          type: string
+    required:
+      - name
+    additionalProperties: false
+  # domain controller group entries
+  domain_group_entry:
+    description: |
+      A group that will be created in the specified AD domain. These
+      groups are populated in the directory after the domain is provisioned.
+    type: object
+    properties:
+      name:
+        description: The group name
+        type: string
+      gid:
+        type: integer
+    required:
+      - name
+    additionalProperties: false
+properties:
+  samba-container-config:
+    type: "string"
+    title: "Cofiguration Format Version"
+    description: |
+      A short version string that assists in allowing the configuration
+      format to (some day) support incompatible version changes.
+      (It is unique to the configuration and is not the version of sambacc)
+  # top-level configuration section. each subsection is an "instance" -
+  # a single server or a group of servers acting as one unit.
+  # You can store multiple instance configurations in a single config and
+  # use the sambacc --identity/SAMBA_CONTAINER_ID to select between them.
+  configs:
+    title: "Container Configurations"
+    description: |
+      A mapping of named configurations (instances) to top-level configuration
+      blocks. A useable configuration file must have at least one configuration,
+      but more than one is supported.
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        shares:
+          $ref: "#/$defs/section_choices"
+        globals:
+          $ref: "#/$defs/section_choices"
+        instance_features:
+          $ref: "#/$defs/feature_flags"
+        permissions:
+          $ref: "#/$defs/permissions_config"
+        instance_name:
+          description: |
+            A name that will be set for the server instance.
+          type: string
+        domain_settings:
+          description: |
+            The name of the domain settings. Only used with 'ADDC' feature flag.
+          type: string
+      additionalProperties: false
+  # share defintions.
+  shares:
+    description: |
+      A mapping of share name to share specific configuration. A share can
+      have "options" that are passed to Samba. Shares can have an optional
+      "permissions" section for managing permissions/acls in sambacc.
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        options:
+          $ref: "#/$defs/samba_options"
+        permissions:
+          $ref: "#/$defs/permissions_config"
+      additionalProperties: false
+  # globals defintions.
+  globals:
+    description: |
+      A mapping of samba global configuation blocks. The global section names
+      are not passed to Samba. All sections selected by a configuration are
+      merged together before passing to Samba.
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        options:
+          $ref: "#/$defs/samba_options"
+      additionalProperties: false
+  # domain_settings configures an AD DC based instance
+  domain_settings:
+    description: |
+      A mapping of AD DC domain configuration keys to domain configurations.
+      These parameters are used when provisioning an AD DC instance.
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        realm:
+          type: string
+        short_domain:
+          type: string
+        admin_password:
+          type: string
+      required:
+        - realm
+      additionalProperties: false
+  # users to be set up in the container environment prior to starting
+  # a samba fileserver
+  users:
+    description: |
+      Users to add to the container environment in order to provide
+      Share access-control wihout becoming a domain member server.
+    type: object
+    properties:
+      all_entries:
+        type: array
+        items:
+          $ref: "#/$defs/user_entry"
+  # groups to be set up in the container environment prior to starting
+  # a samba fileserver
+  groups:
+    description: |
+      Groups to add to the container environment in order to provide
+      Share access-control wihout becoming a domain member server.
+    type: object
+    properties:
+      all_entries:
+        type: array
+        items:
+          $ref: "#/$defs/group_entry"
+  # domain_users are users that will be initialized for a new AD DC instance
+  domain_users:
+    description: |
+      The domain_users section defines initial users that will be automatically
+      added to a newly provisioned domain. This section is a mapping of the
+      domain settings name to a list of domain user entries.
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        $ref: "#/$defs/domain_user_entry"
+  # domain_groups are groups that will be initialized for a new AD DC instance
+  domain_groups:
+    description: |
+      The domain_groups section defines initial groups that will be
+      automatically added to a newly provisioned domain. This section is
+      a mapping of the domain settings name to a list of domain group entries.
+    type: object
+    additionalProperties:
+      type: array
+      items:
+        $ref: "#/$defs/domain_group_entry"
+  # ctdb customization settings
+  # generally for developers/expert users only. these ctdb specific overrides
+  # live outside the smb.conf and have their own section
+  ctdb:
+    type: object
+    additionalProperties:
+      type: string
+additionalProperties: false
+required:
+  - samba-container-config
+# we use the following patternProperties to allow any key starting
+# with underscores so that the writer of the config can add extra
+# metadata or comments freely.
+patternProperties:
+  "^_": true

--- a/sambacc/schema/conf_v0_schema.py
+++ b/sambacc/schema/conf_v0_schema.py
@@ -1,0 +1,316 @@
+#!/usr/bin/python3
+# --- GENERATED FILE --- DO NOT EDIT --- #
+# --- generated from: conf-v0.schema.yaml
+
+SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "mailto:phlogistonjohn+sambacc-v0@asynchrono.us",
+    "title": "sambacc configuration",
+    "description": (
+        "The configuration for the sambacc tool. sambacc configures Samba and"
+        " the container\nenvironment to fit Samba's unique needs. This"
+        " configuration can hold configuration\nfor more than one server"
+        ' "instance". The "configs" section contains one or'
+        " more\nconfiguration with a name that can be selected at runtime."
+        " Share definitions\nand samba global configuration blocks can be"
+        " mixed and matched.\n"
+    ),
+    "type": "object",
+    "$defs": {
+        "section_choices": {
+            "description": (
+                "Selects sub-sections from elsewhere in the configuration.\n"
+            ),
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "feature_flags": {
+            "description": (
+                "Feature flags are used to enable specific, wide-ranging,"
+                " features of\nsambacc. For example, it is used to enable"
+                " clustered mode with ctdb.\n"
+            ),
+            "type": "array",
+            "items": {"enum": ["addc", "ctdb"]},
+        },
+        "samba_options": {
+            "description": (
+                "A mapping of values that will be passed into the smb.conf"
+                " (or equivalent)\nto directly configure Samba.\n"
+            ),
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+        "permissions_config": {
+            "description": (
+                "Settings that enable and manage sambacc's permissions"
+                " management support.\n"
+            ),
+            "type": "object",
+            "properties": {
+                "method": {
+                    "description": (
+                        "Backend method for controlling permissions on shares"
+                    ),
+                    "type": "string",
+                },
+                "status_xattr": {
+                    "description": (
+                        "xattr name used to store permissions state"
+                    ),
+                    "type": "string",
+                },
+            },
+            "additionalProperties": {"type": "string"},
+        },
+        "user_entry": {
+            "description": (
+                "A user that will be instantiated in the local contianer"
+                " environment to\nin order to provide access to smb shares.\n"
+            ),
+            "type": "object",
+            "properties": {
+                "name": {"description": "The user's name", "type": "string"},
+                "uid": {
+                    "description": "The Unix UID the user should have",
+                    "type": "integer",
+                },
+                "gid": {
+                    "description": "The Unix GID the user should have",
+                    "type": "integer",
+                },
+                "nt_hash": {
+                    "description": "An NT-Hashed password",
+                    "type": "string",
+                },
+                "password": {
+                    "description": "A plain-text password",
+                    "type": "string",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        "group_entry": {
+            "description": (
+                "A group that will be instantiated in the local contianer"
+                " environment to\nin order to provide access to smb shares.\n"
+            ),
+            "type": "object",
+            "properties": {
+                "name": {"description": "The group name", "type": "string"},
+                "gid": {
+                    "description": "The Unix GID the group should have",
+                    "type": "integer",
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        "domain_user_entry": {
+            "description": (
+                "A user that will be created in the specified AD domain."
+                " These\nusers are populated in the directory after the"
+                " domain is provisioned.\n"
+            ),
+            "type": "object",
+            "properties": {
+                "name": {"description": "The user's name", "type": "string"},
+                "surname": {
+                    "description": "A surname for the user",
+                    "type": "string",
+                },
+                "given_name": {
+                    "description": "A given name for the user",
+                    "type": "string",
+                },
+                "uid": {"type": "integer"},
+                "gid": {"type": "integer"},
+                "nt_hash": {"type": "string"},
+                "password": {
+                    "description": "A plain-text password",
+                    "type": "string",
+                },
+                "member_of": {
+                    "description": (
+                        "A list of group names that the user should belong to"
+                    ),
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+        "domain_group_entry": {
+            "description": (
+                "A group that will be created in the specified AD domain."
+                " These\ngroups are populated in the directory after the"
+                " domain is provisioned.\n"
+            ),
+            "type": "object",
+            "properties": {
+                "name": {"description": "The group name", "type": "string"},
+                "gid": {"type": "integer"},
+            },
+            "required": ["name"],
+            "additionalProperties": False,
+        },
+    },
+    "properties": {
+        "samba-container-config": {
+            "type": "string",
+            "title": "Cofiguration Format Version",
+            "description": (
+                "A short version string that assists in allowing the"
+                " configuration\nformat to (some day) support incompatible"
+                " version changes.\n(It is unique to the configuration and is"
+                " not the version of sambacc)\n"
+            ),
+        },
+        "configs": {
+            "title": "Container Configurations",
+            "description": (
+                "A mapping of named configurations (instances) to top-level"
+                " configuration\nblocks. A useable configuration file must"
+                " have at least one configuration,\nbut more than one is"
+                " supported.\n"
+            ),
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "shares": {"$ref": "#/$defs/section_choices"},
+                    "globals": {"$ref": "#/$defs/section_choices"},
+                    "instance_features": {"$ref": "#/$defs/feature_flags"},
+                    "permissions": {"$ref": "#/$defs/permissions_config"},
+                    "instance_name": {
+                        "description": (
+                            "A name that will be set for the server"
+                            " instance.\n"
+                        ),
+                        "type": "string",
+                    },
+                    "domain_settings": {
+                        "description": (
+                            "The name of the domain settings. Only used with"
+                            " 'ADDC' feature flag.\n"
+                        ),
+                        "type": "string",
+                    },
+                },
+                "additionalProperties": False,
+            },
+        },
+        "shares": {
+            "description": (
+                "A mapping of share name to share specific configuration. A"
+                ' share can\nhave "options" that are passed to Samba. Shares'
+                ' can have an optional\n"permissions" section for managing'
+                " permissions/acls in sambacc.\n"
+            ),
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "options": {"$ref": "#/$defs/samba_options"},
+                    "permissions": {"$ref": "#/$defs/permissions_config"},
+                },
+                "additionalProperties": False,
+            },
+        },
+        "globals": {
+            "description": (
+                "A mapping of samba global configuation blocks. The global"
+                " section names\nare not passed to Samba. All sections"
+                " selected by a configuration are\nmerged together before"
+                " passing to Samba.\n"
+            ),
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {"options": {"$ref": "#/$defs/samba_options"}},
+                "additionalProperties": False,
+            },
+        },
+        "domain_settings": {
+            "description": (
+                "A mapping of AD DC domain configuration keys to domain"
+                " configurations.\nThese parameters are used when"
+                " provisioning an AD DC instance.\n"
+            ),
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "realm": {"type": "string"},
+                    "short_domain": {"type": "string"},
+                    "admin_password": {"type": "string"},
+                },
+                "required": ["realm"],
+                "additionalProperties": False,
+            },
+        },
+        "users": {
+            "description": (
+                "Users to add to the container environment in order to"
+                " provide\nShare access-control wihout becoming a domain"
+                " member server.\n"
+            ),
+            "type": "object",
+            "properties": {
+                "all_entries": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/user_entry"},
+                }
+            },
+        },
+        "groups": {
+            "description": (
+                "Groups to add to the container environment in order to"
+                " provide\nShare access-control wihout becoming a domain"
+                " member server.\n"
+            ),
+            "type": "object",
+            "properties": {
+                "all_entries": {
+                    "type": "array",
+                    "items": {"$ref": "#/$defs/group_entry"},
+                }
+            },
+        },
+        "domain_users": {
+            "description": (
+                "The domain_users section defines initial users that will be"
+                " automatically\nadded to a newly provisioned domain. This"
+                " section is a mapping of the\ndomain settings name to a list"
+                " of domain user entries.\n"
+            ),
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/domain_user_entry"},
+            },
+        },
+        "domain_groups": {
+            "description": (
+                "The domain_groups section defines initial groups that will"
+                " be\nautomatically added to a newly provisioned domain. This"
+                " section is\na mapping of the domain settings name to a list"
+                " of domain group entries.\n"
+            ),
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/domain_group_entry"},
+            },
+        },
+        "ctdb": {
+            "type": "object",
+            "additionalProperties": {"type": "string"},
+        },
+    },
+    "additionalProperties": False,
+    "required": ["samba-container-config"],
+    "patternProperties": {"^_": True},
+}

--- a/sambacc/schema/tool.py
+++ b/sambacc/schema/tool.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python3
+"""Convert or compare schema files written in YAML to the corresponding
+files stored in JSON.
+"""
+
+import argparse
+import collections
+import json
+import os
+import pprint
+import subprocess
+import sys
+
+import yaml
+
+
+nameparts = collections.namedtuple("nameparts", "full head ext")
+filepair = collections.namedtuple("filepair", "origin dest format")
+
+
+def _namesplit(name):
+    head, ext = name.split(".", 1)
+    return nameparts(name, head, ext)
+
+
+def _pyname(np):
+    head = np.head.replace("-", "_")
+    if np.ext.startswith("schema."):
+        head += "_schema"
+    ext = "py"
+    return nameparts(f"{head}.{ext}", head, ext)
+
+
+def _format_black(path):
+    # black does not formally have an api. Safeset way to use it is via
+    # the cli
+    path = os.path.abspath(path)
+    # the --preview arg allows black to break up long strings that
+    # the general check would discover and complain about. Otherwise
+    # we'd be forced to ignore the formatting on these .py files.
+    subprocess.run(["black", "-l78", "--preview", path], check=True)
+
+
+def match(files):
+    yamls = []
+    jsons = []
+    pys = []
+    for fname in files:
+        try:
+            np = _namesplit(fname)
+        except ValueError:
+            continue
+        if np.ext == "schema.yaml":
+            yamls.append(np)
+        if np.ext == "schema.json":
+            jsons.append(np)
+        if np.ext == "py":
+            pys.append(np)
+    pairs = []
+    for yname in yamls:
+        for jname in jsons:
+            if jname.head == yname.head:
+                pairs.append(filepair(yname, jname, "JSON"))
+                break
+        else:
+            pairs.append(filepair(yname, None, "JSON"))
+        for pyname in pys:
+            if _pyname(yname).head == pyname.head:
+                pairs.append(filepair(yname, pyname, "PYTHON"))
+                break
+        else:
+            pairs.append(filepair(yname, None, "PYTHON"))
+    return pairs
+
+
+def report(func, path, yaml_file, json_file, fmt):
+    needs_update = func(path, yaml_file, json_file, fmt)
+    json_name = "---" if not json_file else json_file.full
+    if not needs_update:
+        print(f"{yaml_file.full} -> {fmt.lower()}:{json_name}   OK")
+        return None
+    print(f"{yaml_file.full} -> {fmt.lower()}:{json_name}   MISMATCH")
+    return True
+
+
+def update_json(path, yaml_file, json_file):
+    yaml_path = os.path.join(path, yaml_file.full)
+    json_path = os.path.join(path, f"{yaml_file.head}.schema.json")
+    with open(yaml_path) as fh:
+        yaml_data = yaml.safe_load(fh)
+    with open(json_path, "w") as fh:
+        json.dump(yaml_data, fh, indent=2)
+
+
+def compare_json(path, yaml_file, json_file):
+    if json_file is None:
+        return True
+    yaml_path = os.path.join(path, yaml_file.full)
+    json_path = os.path.join(path, json_file.full)
+    with open(yaml_path) as fh:
+        yaml_data = yaml.safe_load(fh)
+    with open(json_path) as fh:
+        json_data = json.load(fh)
+    return yaml_data != json_data
+
+
+def update_py(path, yaml_file, py_file):
+    yaml_path = os.path.join(path, yaml_file.full)
+    py_path = os.path.join(path, _pyname(yaml_file).full)
+    with open(yaml_path) as fh:
+        yaml_data = yaml.safe_load(fh)
+    out = []
+    out.append("#!/usr/bin/python3")
+    out.append("# --- GENERATED FILE --- DO NOT EDIT --- #")
+    out.append(f"# --- generated from: {yaml_file.full}")
+    out.append("")
+    out.append(
+        "SCHEMA = " + pprint.pformat(yaml_data, width=800, sort_dicts=False)
+    )
+    content = "\n".join(out)
+    with open(py_path, "w") as fh:
+        fh.write(content)
+    _format_black(py_path)
+
+
+def compare_py(path, yaml_file, py_file):
+    if py_file is None:
+        return True
+    yaml_path = os.path.join(path, yaml_file.full)
+    py_path = os.path.join(path, py_file.full)
+    with open(yaml_path) as fh:
+        yaml_data = yaml.safe_load(fh)
+    with open(py_path) as fh:
+        py_locals = {}
+        exec(fh.read(), None, py_locals)
+    py_data = py_locals.get("SCHEMA") or {}
+    return yaml_data != py_data
+
+
+def update(path, yaml_data, other_file, fmt):
+    if fmt == "PYTHON":
+        return update_py(path, yaml_data, other_file)
+    return update_json(path, yaml_data, other_file)
+
+
+def compare(path, yaml_data, other_file, fmt):
+    if fmt == "PYTHON":
+        return compare_py(path, yaml_data, other_file)
+    return compare_json(path, yaml_data, other_file)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("DIR", default=os.path.dirname(__file__), nargs="?")
+    parser.add_argument("--update", action="store_true")
+    cli = parser.parse_args()
+
+    mismatches = []
+    os.chdir(cli.DIR)
+    fn = update if cli.update else compare
+    pairs = match(os.listdir("."))
+    for pair in pairs:
+        mismatches.append(report(fn, ".", *pair))
+    if any(mismatches):
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -94,6 +94,7 @@ class FakeContext:
         self.instance_config = instance_config
         for k, v in opts.items():
             setattr(self.cli, k, v)
+        self.require_validation = False
 
     @classmethod
     def defaults(cls, cfg_path, watch=False):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -530,42 +530,36 @@ def test_ad_dc_invalid():
 
 
 def test_ad_dc_bad_member_of():
-    jdata = """
-{
-  "samba-container-config": "v0",
-  "configs": {
-    "demo": {
-      "instance_features": ["addc"],
-      "domain_settings": "sink",
-      "instance_name": "dc1"
+    jdata = {
+        "samba-container-config": "v0",
+        "configs": {
+            "demo": {
+                "instance_features": ["addc"],
+                "domain_settings": "sink",
+                "instance_name": "dc1",
+            }
+        },
+        "domain_settings": {
+            "sink": {
+                "realm": "DOMAIN1.SINK.TEST",
+                "short_domain": "DOMAIN1",
+                "admin_password": "Passw0rd",
+            }
+        },
+        "domain_groups": {"sink": [{"name": "friends"}]},
+        "domain_users": {
+            "sink": [
+                {
+                    "name": "ckent",
+                    "password": "1115Rose.",
+                    "given_name": "Clark",
+                    "surname": "Kent",
+                    "member_of": "friends",
+                }
+            ]
+        },
     }
-  },
-  "domain_settings": {
-    "sink": {
-      "realm": "DOMAIN1.SINK.TEST",
-      "short_domain": "DOMAIN1",
-      "admin_password": "Passw0rd"
-    }
-  },
-  "domain_groups": {
-    "sink": [
-      {"name": "friends"}
-    ]
-  },
-  "domain_users": {
-    "sink": [
-      {
-        "name": "ckent",
-        "password": "1115Rose.",
-        "given_name": "Clark",
-        "surname": "Kent",
-        "member_of": "friends"
-      }
-    ]
-  }
-}
-    """
-    c1 = sambacc.config.GlobalConfig(io.StringIO(jdata))
+    c1 = sambacc.config.GlobalConfig(initial_data=jdata)
     i1 = c1.get("demo")
     assert i1.with_addc
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -529,7 +529,7 @@ def test_ad_dc_invalid():
         list(i1.domain_groups())
 
 
-def test_ad_dc_bad_memeber_of():
+def test_ad_dc_bad_member_of():
     jdata = """
 {
   "samba-container-config": "v0",

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pytest
     pytest-cov
     dnspython
+    jsonschema
 commands =
     py.test -v tests --cov=sambacc --cov-report=html {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = formatting, {py3,py39}-mypy, py3, py39
+envlist = formatting, {py3,py39}-mypy, py3, py39, schemacheck
 isolated_build = True
 
 [testenv]
@@ -47,3 +47,10 @@ deps =
 commands =
     flake8 sambacc tests
     black --check -v .
+
+[testenv:schemacheck]
+deps =
+    black
+    PyYAML
+commands =
+    python -m sambacc.schema.tool

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,9 @@ commands =
 [testenv:{py3,py39}-mypy]
 deps =
     mypy
+    types-setuptools
+    types-jsonschema
+    types-pyyaml
     {[testenv]deps}
 commands =
     mypy sambacc tests


### PR DESCRIPTION
Fixes: #67 

Add [jsonschema](http://json-schema.org) support to sambacc.  We add a new subdir `sambacc/schema` that holds the canonical YAML schema files and generated files derived from the YAML sources.
A new tool that can be invoked on the cli by `python -m sambacc.schema.tool` is added to help manage the schema files and ensure they are kept in sync.

The sambacc.config module is updated to take advantage to schema based validation when the python jsonschema library is available. On the CLI one can request automatic validation (validate if library is present) or require or disable validation. The `auto` option is the default.

Since this PR is already long-ish I'm avoiding two things:
* Trying to cover all cases in the schema. I'm sure that there are gaps. This builds the infra and we can fill in some of the gaps over time.
* Dealing with distro packaging. That'll be done in follow up PR(s) as I need to manully test various scenarios and I have other packaging related TODOs.