### PR TITLE
addc: Use `--adprep-level` to provision domain as workaround

### DIFF
--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -110,6 +110,7 @@ def _provision_cmd(
         f"--realm={realm}",
         f"--domain={domain}",
         f"--adminpass={admin_password}",
+        "--adprep-level=SKIP",
     ].argv()
     return cmd
 


### PR DESCRIPTION
Quick reference: upstream [commit](https://git.samba.org/?p=samba.git;a=commit;h=4bba26579d124af6c0767bb98bee67357001e1e7)

Upstream discussion: https://lists.samba.org/archive/samba-technical/2023-March/138102.html

MR: https://gitlab.com/samba-team/samba/-/merge_requests/2991