### PR TITLE
Add support for config files in TOML and YAML formats

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,9 +1,14 @@
 
 # JSON Configuration Format
 
-Much of the behavior of sambacc is driven by the JSON based
-configuration file. The following is a high level example of the JSON
+Much of the behavior of sambacc is driven by the
+configuration files. The following is a high level example of the JSON
 structure and a description of these sections.
+
+If sambacc is installed with the `yaml` extra it can support [YAML](#yaml)
+based configuration files. If sambacc is installed with the `toml` extra it can
+support [TOML](#toml) based configuration files. The JSON support is the
+default and is always present.
 
 ```json
 {
@@ -278,3 +283,98 @@ A domain user entry is as follows:
 * `password` - A plain-text password.
 * `member_of` - Optional. List of group names. The user will be added to the listed
   groups.
+
+
+# YAML
+
+The [YAML](https://yaml.org/) format may be used to configure sambacc when
+PyYAML library is available. The YAML configuration is effectively converted to
+JSON internally when processed. All of the documentation applying to the JSON
+based configuration applies but in a somewhat easier to write format. The
+filename must end with `.yaml` or `.yml` for sambacc to parse the file as YAML.
+
+An example of a YAML based configuration file:
+```yaml
+samba-container-config: v0
+# Define top-level configurations
+configs:
+  try2:
+    globals: ["default"]
+    shares:
+      - "example"
+      - "Other Name"
+# Define Global Options
+globals:
+  default:
+    options:
+      load printers: "no"
+      printing: "bsd"
+      printcap name: "/dev/null"
+      disable spoolss: "yes"
+      guest ok: "no"
+      security: "user"
+      server min protocol: "SMB2"
+# Define Shares
+shares:
+  example:
+    options:
+      path: /srv/a
+      read only: "no"
+  Other Name:
+    options:
+      path: /srv/b
+      read only: "no"
+# Define users
+users:
+  all_entries:
+    - {"name": "sambauser", "password": "samba"}
+    - {"name": "otheruser", "password": "insecure321"}
+```
+
+# TOML
+
+The [TOML](https://toml.io/en/) format may be used to configure sambacc when
+used on Python 3.11 or later or when the tomli library is available. The TOML
+format may seem similar to the INI-style format used by Samba.  The TOML
+configuration is effectively converted to JSON internally when processed. All
+of the documentation applying to the JSON based configuration applies but in a
+somewhat easier to read and write format. The filename must end with `.toml` for
+sambacc to parse the file as TOML.
+
+An example of a TOML based configuration file:
+```toml
+samba-container-config = "v0"
+
+# Define top level configurations
+[configs.try1]
+globals = ["default"]
+shares = ["example", "Other Name"]
+
+# Define shares
+[shares.example.options]
+path = "/srv/a"
+"read only" = "no"
+
+[shares."Other Name".options]
+path = "/srv/b"
+"read only" = "no"
+
+# Define global options
+[globals.default.options]
+"load printers" = "no"
+printing = "bsd"
+"printcap name" = "/dev/null"
+"disable spoolss" = "yes"
+"guest ok" = "no"
+security = "user"
+"server min protocol" = "SMB2"
+
+# Define users
+[[users.all_entries]]
+name = "sambauser"
+password = "samba"
+
+[[users.all_entries]]
+name = "otheruser"
+password = "insecure321"
+```

--- a/extras/python-sambacc.spec
+++ b/extras/python-sambacc.spec
@@ -40,6 +40,11 @@ Summary: %{summary}
 # Distro requires that are technically optional for the lib
 Requires: python3-samba
 Requires: python3-pyxattr
+%if 0%{?fedora} >= 37
+Recommends: %{name}+toml
+Recommends: %{name}+validation
+Recommends: %{name}+yaml
+%endif
 
 %description -n python3-%{bname}  %_description
 

--- a/extras/python-sambacc.spec
+++ b/extras/python-sambacc.spec
@@ -72,6 +72,8 @@ Requires: python3-pyxattr
 
 
 %pyproject_extras_subpkg -n python3-%{bname} validation
+%pyproject_extras_subpkg -n python3-%{bname} toml
+%pyproject_extras_subpkg -n python3-%{bname} yaml
 
 
 %changelog

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -80,7 +80,13 @@ if sys.version_info >= (3, 11):
 else:
 
     def _load_toml(source: typing.IO) -> JSONData:
-        raise ConfigFormatUnsupported(ConfigFormat.TOML)
+        try:
+            import tomli
+        except ImportError:
+            raise ConfigFormatUnsupported(ConfigFormat.TOML)
+        if typing.TYPE_CHECKING:
+            assert isinstance(source, typing.BinaryIO)
+        return tomli.load(source)
 
 
 def _load_yaml(source: typing.IO) -> JSONData:

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,3 +31,7 @@ share/sambacc/examples =
 [options.extras_require]
 validation =
     jsonschema>=4.10
+yaml =
+    PyYAML>=5.4
+toml =
+    tomli;python_version<"3.11"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -756,6 +756,23 @@ def test_permissions_config_options():
     assert "friendship" in opts
 
 
+def _can_import_toml():
+    """Return true if one valid toml module can be imported.
+    Work around importorskip only supporting one module name.
+    """
+    try:
+        __import__("tomllib")
+        return True
+    except ImportError:
+        pass
+    try:
+        __import__("tomli")
+        return True
+    except ImportError:
+        pass
+    return False
+
+
 @pytest.mark.parametrize(
     "json_str,ok",
     [
@@ -943,9 +960,8 @@ a = "b"
         ),
     ],
 )
+@pytest.mark.skipif(not _can_import_toml(), reason="no toml module")
 def test_toml_configs_no_validation(toml_str, ok):
-    pytest.importorskip("tomllib")
-
     cfg = sambacc.config.GlobalConfig()
     fh = io.BytesIO(toml_str.encode("utf8"))
     if ok:
@@ -1059,8 +1075,8 @@ password = "insecure321"
         ),
     ],
 )
+@pytest.mark.skipif(not _can_import_toml(), reason="no toml module")
 def test_toml_configs_validation(toml_str, ok):
-    pytest.importorskip("tomllib")
     jsonschema = pytest.importorskip("jsonschema")
 
     cfg = sambacc.config.GlobalConfig()

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     pytest
     pytest-cov
     dnspython
-    -e .[validation]
+    -e .[validation,yaml,toml]
 commands =
     py.test -v tests --cov=sambacc --cov-report=html {posargs}
 
@@ -22,6 +22,7 @@ deps =
     types-setuptools
     types-pyyaml
     types-jsonschema>=4.10
+    tomli
     {[testenv]deps}
 commands =
     mypy sambacc tests


### PR DESCRIPTION
Depends on: #69 

JSON is great in that it is standardized, tons of languages support it, and it's pretty simple to parse and work with. It is pretty terrible to edit by hand though. This PR adds support for both TOML and YAML as formats for our sambacc configuration.  The intent here is to make writing a config by hand simpler and thus using samba-container directly without management by the operator, for example, easier.

TOML is probably the nicest to work with once you memorize the rules around brackets (tables vs. arrays of tables).  This module is included in python, however, the python version must be 3.11 or later.

YAML is a superset of JSON that is much easier to write and is extremely popular, if a bit over-complicated.

The file format to use is selected based on the file name's extension. To use TOML the file name must end with ".toml". To use YAML the file name must end with either ".yml" or ".yaml". 

These changes build upon the work to use jsonschema. Despite the name the jsonschema can be applied to both these formats as it's really describing the underlying strucutre of the data (not the formatting) and both new formats are largely json-compatible, with similar structural and basic data types.


TODO:
* [x] Actually test it in a built samba container
* [x] Document the new formats with examples and descriptions
* [x] Update test deps to run (not skip) the newly added unit tests 
