### PR TITLE
fix rpm build issues introduced by jsonschema feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Build test container
       run: docker build  -t sambacc:ci  tests/container/ -f tests/container/Containerfile
     - name: Run test container

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -54,7 +54,7 @@ class ValidationUnsupported(Exception):
 
 def _schema_validate(data: dict[str, typing.Any], version: str) -> None:
     try:
-        import jsonschema
+        import jsonschema  # type: ignore[import]
     except ImportError:
         raise ValidationUnsupported()
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ url = https://github.com/samba-in-kubernetes/sambacc
 license = GPL3
 
 [options]
-packages = sambacc, sambacc.commands
+packages = sambacc, sambacc.commands, sambacc.schema
 include_package_data = True
 
 [options.entry_points]

--- a/tests/container/build.sh
+++ b/tests/container/build.sh
@@ -151,6 +151,12 @@ task_py_build() {
     # only
     distdir="$(get_distdir "$distname")"
     info "using dist dir: $distdir"
+
+    # setuptools_scm calls into git, newer git versions have stricter ownership
+    # rules that can break our builds when mounted into a container. Tell our
+    # in-container git, that it's all ok and the monsters aren't real.
+    # This config will vanish once the container exits anyway.
+    git config --global --add safe.directory "${bdir}"
     $python -m build --outdir "$distdir"
 }
 

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ deps =
     pytest
     pytest-cov
     dnspython
-    jsonschema
 commands =
     py.test -v tests --cov=sambacc --cov-report=html {posargs}
 
@@ -20,7 +19,6 @@ commands =
 deps =
     mypy
     types-setuptools
-    types-jsonschema
     types-pyyaml
     {[testenv]deps}
 commands =


### PR DESCRIPTION
Upon merging #69 the samba-container builds broke. 

The RPM build failed because the tox test dependencies listed jsonschema and no jsonschema python packages were installed. On top of that, the python3-jsonschema package in fedora 36 is incompatible and breaks the tests. So we're mostly just undoing the initial damage to try and get samba-containers working again.

To prevent future damage this PR enables the CI to run the RPM build step which was previously skipped (and only executed by samba-container builds).