### PR TITLE
Add more distros to CI test runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
       run: docker run -v $PWD:/var/tmp/build/sambacc sambacc:ci-fc37
 
   push:
+    needs: [test]
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'samba-in-kubernetes/sambacc'
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,26 @@ jobs:
       run: docker build  -t sambacc:ci  tests/container/ -f tests/container/Containerfile
     - name: Run test container
       run: docker run -v $PWD:/var/tmp/build/sambacc sambacc:ci
+  test-centos-stream9:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Build test container
+      run: docker build --build-arg=SAMBACC_BASE_IMAGE=quay.io/centos/centos:stream9 -t sambacc:ci-cs9 tests/container/ -f tests/container/Containerfile
+    - name: Run test container
+      run: docker run -v $PWD:/var/tmp/build/sambacc sambacc:ci-cs9
+  test-fedora37:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Build test container
+      run: docker build --build-arg=SAMBACC_BASE_IMAGE=registry.fedoraproject.org/fedora:37 -t sambacc:ci-fc37 tests/container/ -f tests/container/Containerfile
+    - name: Run test container
+      run: docker run -v $PWD:/var/tmp/build/sambacc sambacc:ci-fc37
 
   push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Depends on: #74 

Adds additional test runs using centos stream 9 and fedora 37 base images.

Also adds a change not to run 'push' job unless 'test' succeeds