### PR TITLE
tox: add a distinct test env for system packages

### DIFF
--- a/extras/python-sambacc.spec
+++ b/extras/python-sambacc.spec
@@ -67,3 +67,4 @@ Requires: python3-pyxattr
 
 
 %changelog
+%autochangelog

--- a/extras/python-sambacc.spec
+++ b/extras/python-sambacc.spec
@@ -43,7 +43,7 @@ Requires: python3-pyxattr
 %autosetup -n %{bname}-%{pversion}
 
 %generate_buildrequires
-%pyproject_buildrequires -e py3
+%pyproject_buildrequires -e py3-sys
 
 
 %build
@@ -56,7 +56,7 @@ Requires: python3-pyxattr
 
 
 %check
-%tox -e py3
+%tox -e py3-sys
 
 
 %files -n python3-%{bname} -f %{pyproject_files}

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,3 +27,7 @@ share/sambacc/examples =
   examples/example1.json
   examples/minimal.json
   examples/addc.json
+
+[options.extras_require]
+validation =
+    jsonschema>=4.10

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = formatting, {py3,py39}-mypy, py3, py39, schemacheck
+envlist = formatting, {py3,py39}-mypy, py3, py39, schemacheck, py3-sys
 isolated_build = True
 
 [testenv]
@@ -20,11 +20,14 @@ deps =
     mypy
     types-setuptools
     types-pyyaml
+    types-jsonschema>=4.10
     {[testenv]deps}
 commands =
     mypy sambacc tests
 
-[testenv:py3]
+[testenv:py3-sys]
+# py3-sys -- more like sisyphus, am I right?
+#
 # In order to run tests that rely on "system level" packages (samba,
 # xattr, etc.), and not have a lot of test skips, we have to enable the
 # sitepackages option. However when it is enabled and you already have a tool
@@ -34,9 +37,13 @@ commands =
 # section.
 sitepackages = True
 deps =
+    pytest
+    pytest-cov
+    dnspython
     inotify_simple
     pyxattr
-    {[testenv]deps}
+allowlist_externals =
+    /usr/bin/py.test
 
 [testenv:formatting]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     pytest
     pytest-cov
     dnspython
+    -e .[validation]
 commands =
     py.test -v tests --cov=sambacc --cov-report=html {posargs}
 


### PR DESCRIPTION
Depends on: #76 

This PR is a bit of a grab bag of stuff but the main point is to disentangle the test environments "normally" used by tox and when we include system packages (AKA site packages).
Thus the "py<N>" packages will *always* use the isolated virtualenvs and the new "py3-sys" environment will use site packages.

This then adapts the rpm spec to use the new env, fixes a warning, and also teaches tox about our first optional dependency specified as an extra.