### PR TITLE
Add initial support for building sambacc rpms via COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,29 @@
+
+
+SELF=$(lastword $(MAKEFILE_LIST))
+ROOT_DIR=$(abspath $(dir $(SELF))/..)
+SKIP_DEPS=
+
+outdir:=/var/tmp/copr-tmp-outdir
+spec:=extras/python-sambacc.spec
+
+.PHONY: srpm
+srpm: sys_deps
+	mkdir -p $(outdir)
+	git fetch --tags
+	SAMBACC_SRPM_ONLY=yes \
+		SAMBACC_BUILD_DIR=$(ROOT_DIR) \
+		SAMBACC_DIST_PREFIX=$(outdir)/.dist \
+		SAMBACC_DISTNAME=copr \
+		SAMBACC_BUILD_TASKS="task_py_build task_rpm_build" \
+		 ./tests/container/build.sh
+	cp $(outdir)/.dist/copr/SRPMS/*.rpm  $(outdir)
+
+
+.PHONY: sys_deps
+sys_deps:
+ifeq ($(SKIP_DEPS),yes)
+	@echo "Skipping sys deps"
+else
+	dnf install -y python3-pip git
+endif

--- a/extras/python-sambacc.spec
+++ b/extras/python-sambacc.spec
@@ -66,5 +66,8 @@ Requires: python3-pyxattr
 %{_datadir}/%{bname}/examples/
 
 
+%pyproject_extras_subpkg -n python3-%{bname} validation
+
+
 %changelog
 %autochangelog

--- a/extras/python-sambacc.spec
+++ b/extras/python-sambacc.spec
@@ -37,7 +37,7 @@ supporting components.
 
 %package -n python3-%{bname}
 Summary: %{summary}
-# Distro requires that are technially optional for the lib
+# Distro requires that are technically optional for the lib
 Requires: python3-samba
 Requires: python3-pyxattr
 

--- a/extras/python-sambacc.spec
+++ b/extras/python-sambacc.spec
@@ -20,6 +20,11 @@ Source:         %{bname}-%{pversion}.tar.gz
 
 BuildArch:      noarch
 BuildRequires:  python3-devel
+# we need python3-samba as a build dependency in order to run
+# the test suite
+BuildRequires:  python3-samba
+# ditto for the net binary
+BuildRequires: /usr/bin/net
 
 %global _description %{expand:
 A Python library and set of CLI tools intended to act as a bridge between a container

--- a/tests/container/build.sh
+++ b/tests/container/build.sh
@@ -177,12 +177,19 @@ task_rpm_build() {
             rversion="$ver"
         fi
         info "Using rpm-version=${rversion} pkg-version=${ver}"
-        rpmbuild --nocheck -ta \
-            -D "pversion ${ver}" \
-            -D "rversion ${rversion}" \
+        tdir="$(mktemp -d)"
+        (
+            echo "%define pversion ${ver}"
+            echo "%define rversion ${rversion}"
+            tar -xf "$spkg" -O \
+                "sambacc-${ver}/extras/python-sambacc.spec"
+        ) > "${tdir}/python-sambacc.spec"
+        rpmbuild -ba \
             -D "_rpmdir ${distdir}/RPMS" \
             -D "_srcrpmdir ${distdir}/SRPMS" \
-            "$spkg"
+            -D "_sourcedir $(dirname "${spkg}")" \
+            "${tdir}/python-sambacc.spec"
+        rm -rf "${tdir}"
     done
 }
 

--- a/tests/container/build.sh
+++ b/tests/container/build.sh
@@ -178,7 +178,8 @@ task_rpm_build() {
         fi
         info "Using rpm-version=${rversion} pkg-version=${ver}"
         rpmbuild --nocheck -ta \
-            -D "pversion ${ver}" -D"rversion ${rversion}" \
+            -D "pversion ${ver}" \
+            -D "rversion ${rversion}" \
             -D "_rpmdir ${distdir}/RPMS" \
             -D "_srcrpmdir ${distdir}/SRPMS" \
             "$spkg"

--- a/tests/container/build.sh
+++ b/tests/container/build.sh
@@ -9,6 +9,7 @@ distname="${SAMBACC_DISTNAME}"
 # use SAMBACC_BUILD_TASKS to limit build tasks if needed
 tasks="${SAMBACC_BUILD_TASKS:-task_test_tox task_py_build task_rpm_build task_gen_sums}"
 dist_prefix="${SAMBACC_DIST_PREFIX:-/srv/dist}"
+dnf_cmd=dnf
 
 info() {
     echo "[[sambacc/build]] $*"
@@ -129,12 +130,12 @@ task_sys_deps() {
     )
 
     if [ "$use_centos" ]; then
-        yum install -y epel-release
+        "${dnf_cmd}" install -y epel-release
         yum_args=(--enablerepo=crb)
         pkgs+=(pyproject-rpm-macros)
     fi
-    yum "${yum_args[@]}" install -y "${pkgs[@]}"
-    yum clean all
+    "${dnf_cmd}" "${yum_args[@]}" install -y "${pkgs[@]}"
+    "${dnf_cmd}" clean all
 }
 
 task_test_tox() {
@@ -215,6 +216,10 @@ cleanup() {
         rm -rf "$(get_distdir "$distname")"
     fi
 }
+
+if ! command -v "${dnf_cmd}" >/dev/null ; then
+    dnf_cmd=yum
+fi
 
 # Allow the tests to use customized passwd file contents in order
 # to test samba passdb support. It's a bit strange, but should work.


### PR DESCRIPTION
Depends on: #77 

Another grab bag of changes that work up to getting basic support for COPR in place.
Prepare sambacc and the rpm spec file for optional dependencies.
Fix the rpm spec generation to work correctly outside our container env.
Make the build.sh script flexible enough to be reused in the COPR environment. Add a .copr/Makefile for the COPR system to build SRPMs directly from the git checkout.
