### PR TITLE
add support for custom global options in AD DC confgurations

### DIFF
--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -31,6 +31,7 @@ def provision(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
+    options: typing.Optional[typing.Iterable[tuple[str, str]]] = None,
 ) -> None:
     # this function is a direct translation of a previous shell script
     # as samba-tool is based on python libs, this function could possibly
@@ -43,6 +44,7 @@ def provision(
             admin_password=admin_password,
             dns_backend=dns_backend,
             domain=domain,
+            options=options,
         )
     )
     return
@@ -95,6 +97,7 @@ def _provision_cmd(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
+    options: typing.Optional[typing.Iterable[tuple[str, str]]] = None,
 ) -> list[str]:
     if not dns_backend:
         dns_backend = "SAMBA_INTERNAL"
@@ -110,8 +113,12 @@ def _provision_cmd(
         f"--realm={realm}",
         f"--domain={domain}",
         f"--adminpass={admin_password}",
-    ].argv()
-    return cmd
+    ]
+    for okey, oval in options or []:
+        if okey == "netbios name":
+            continue
+        cmd = cmd[f"--option={okey}={oval}"]
+    return cmd.argv()
 
 
 def _join_cmd(

--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -56,6 +56,7 @@ def join(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
+    options: typing.Optional[typing.Iterable[tuple[str, str]]] = None,
 ) -> None:
     _logger.info(f"Joining AD domain: realm={realm}")
     subprocess.check_call(
@@ -64,6 +65,7 @@ def join(
             dcname,
             admin_password=admin_password,
             dns_backend=dns_backend,
+            options=options,
         )
     )
 
@@ -127,6 +129,7 @@ def _join_cmd(
     admin_password: str,
     dns_backend: typing.Optional[str] = None,
     domain: typing.Optional[str] = None,
+    options: typing.Optional[typing.Iterable[tuple[str, str]]] = None,
 ) -> list[str]:
     if not dns_backend:
         dns_backend = "SAMBA_INTERNAL"
@@ -141,8 +144,12 @@ def _join_cmd(
         f"--option=netbios name={dcname}",
         f"--dns-backend={dns_backend}",
         f"--password={admin_password}",
-    ].argv()
-    return cmd
+    ]
+    for okey, oval in options or []:
+        if okey == "netbios name":
+            continue
+        cmd = cmd[f"--option={okey}={oval}"]
+    return cmd.argv()
 
 
 def _user_create_cmd(

--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -93,6 +93,14 @@ def add_group_members(group_name: str, members: list[str]) -> None:
     subprocess.check_call(cmd)
 
 
+def _filter_opts(
+    options: typing.Optional[typing.Iterable[tuple[str, str]]]
+) -> list[tuple[str, str]]:
+    _skip_keys = ["netbios name"]
+    options = options or []
+    return [(k, v) for (k, v) in options if k not in _skip_keys]
+
+
 def _provision_cmd(
     realm: str,
     dcname: str,
@@ -116,10 +124,9 @@ def _provision_cmd(
         f"--domain={domain}",
         f"--adminpass={admin_password}",
     ]
-    for okey, oval in options or []:
-        if okey == "netbios name":
-            continue
-        cmd = cmd[f"--option={okey}={oval}"]
+    cmd = cmd[
+        [f"--option={okey}={oval}" for okey, oval in _filter_opts(options)]
+    ]
     return cmd.argv()
 
 
@@ -145,10 +152,9 @@ def _join_cmd(
         f"--dns-backend={dns_backend}",
         f"--password={admin_password}",
     ]
-    for okey, oval in options or []:
-        if okey == "netbios name":
-            continue
-        cmd = cmd[f"--option={okey}={oval}"]
+    cmd = cmd[
+        [f"--option={okey}={oval}" for okey, oval in _filter_opts(options)]
+    ]
     return cmd.argv()
 
 

--- a/sambacc/commands/addc.py
+++ b/sambacc/commands/addc.py
@@ -86,6 +86,7 @@ def _prep_provision(ctx: Context) -> None:
         domain=domconfig.short_domain,
         dcname=dcname,
         admin_password=domconfig.admin_password,
+        options=ctx.instance_config.global_options(),
     )
 
 
@@ -102,6 +103,7 @@ def _prep_join(ctx: Context) -> None:
         domain=domconfig.short_domain,
         dcname=dcname,
         admin_password=domconfig.admin_password,
+        options=ctx.instance_config.global_options(),
     )
 
 

--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -40,9 +40,6 @@ class Fail(ValueError):
 
 
 class Parser(typing.Protocol):
-    def frank(self, x: str) -> str:
-        ...  # pragma: no cover
-
     def set_defaults(self, **kwargs: typing.Any) -> None:
         ...  # pragma: no cover
 

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -237,7 +237,11 @@ class InstanceConfig:
     def global_options(self) -> typing.Iterable[typing.Tuple[str, str]]:
         """Iterate over global options."""
         # Pull in all global sections that apply
-        gnames = self.iconfig["globals"]
+        try:
+            gnames = self.iconfig["globals"]
+        except KeyError:
+            # no globals section in the instance means no global options
+            return
         for gname in gnames:
             global_section = self.gconfig.data["globals"][gname]
             for k, v in global_section.get("options", {}).items():

--- a/sambacc/smbconf_api.py
+++ b/sambacc/smbconf_api.py
@@ -1,0 +1,73 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2023  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import typing
+
+
+class ConfigStore(typing.Protocol):
+    def __getitem__(self, name: str) -> list[tuple[str, str]]:
+        ...  # pragma: no cover
+
+    def __setitem__(self, name: str, value: list[tuple[str, str]]) -> None:
+        ...  # pragma: no cover
+
+    def __iter__(self) -> typing.Iterator[str]:
+        ...  # pragma: no cover
+
+
+class SimpleConfigStore:
+    def __init__(self) -> None:
+        self._data: dict[str, list[tuple[str, str]]] = {}
+
+    @property
+    def writeable(self) -> bool:
+        """True if using a read-write backend."""
+        return True
+
+    def __getitem__(self, name: str) -> list[tuple[str, str]]:
+        return self._data[name]
+
+    def __setitem__(self, name: str, value: list[tuple[str, str]]) -> None:
+        self._data[name] = value
+
+    def __iter__(self) -> typing.Iterator[str]:
+        return iter(self._data.keys())
+
+    def import_smbconf(
+        self, src: ConfigStore, batch_size: typing.Optional[int] = None
+    ) -> None:
+        """Import content from one SMBConf configuration object into the
+        current SMBConf configuration object.
+
+        batch_size is ignored.
+        """
+        for sname in src:
+            self[sname] = src[sname]
+
+
+def write_store_as_smb_conf(out: typing.IO, conf: ConfigStore) -> None:
+    """Write the configuration store in smb.conf format to `out`."""
+    # unfortunately, AFAIK, there's no way for an smbconf to write
+    # into a an smb.conf/ini style file. We have to do it on our own.
+    # ---
+    # Make sure global section comes first.
+    sections = sorted(conf, key=lambda v: 0 if v == "global" else 1)
+    for sname in sections:
+        out.write(str("\n[{}]\n".format(sname)))
+        for skey, sval in conf[sname]:
+            out.write(str(f"\t{skey} = {sval}\n"))

--- a/sambacc/smbconf_samba.py
+++ b/sambacc/smbconf_samba.py
@@ -1,0 +1,148 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2023  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import sys
+import types
+import importlib
+import typing
+import itertools
+
+from sambacc.smbconf_api import ConfigStore
+
+
+def _smbconf() -> types.ModuleType:
+    return importlib.import_module("samba.smbconf")
+
+
+def _s3smbconf() -> types.ModuleType:
+    return importlib.import_module("samba.samba3.smbconf")
+
+
+def _s3param() -> types.ModuleType:
+    return importlib.import_module("samba.samba3.param")
+
+
+if sys.version_info >= (3, 11):
+    from typing import Self as _Self
+else:
+    _Self = typing.TypeVar("_Self", bound="SMBConf")
+
+
+class SMBConf:
+    """SMBConf wraps the samba smbconf library, supporting reading from and,
+    when possible, writing to samba configuration backends.  The SMBConf type
+    supports transactions using the context managager interface.  The SMBConf
+    type can read and write configuration based on dictionary-like access,
+    using shares as the keys. The global configuration is treated like a
+    special "share".
+    """
+
+    def __init__(self, smbconf: typing.Any) -> None:
+        self._smbconf = smbconf
+
+    @classmethod
+    def from_file(cls: typing.Type[_Self], path: str) -> _Self:
+        """Open a smb.conf style configuration from the specified path."""
+        return cls(_smbconf().init_txt(path))
+
+    @classmethod
+    def from_registry(
+        cls: typing.Type[_Self],
+        configfile: str = "/etc/samba/smb.conf",
+        key: typing.Optional[str] = None,
+    ) -> _Self:
+        """Open samba's registry backend for configuration parameters."""
+        s3_lp = _s3param().get_context()
+        s3_lp.load(configfile)
+        return cls(_s3smbconf().init_reg(key))
+
+    @property
+    def writeable(self) -> bool:
+        """True if using a read-write backend."""
+        return self._smbconf.is_writeable()
+
+    # the extraneous `self: _Self` type makes mypy on python <3.11 happy.
+    # otherwise it complains: `A function returning TypeVar should receive at
+    # least one argument containing the same TypeVar`
+    def __enter__(self: _Self) -> _Self:
+        self._smbconf.transaction_start()
+        return self
+
+    def __exit__(
+        self, exc_type: typing.Any, exc_value: typing.Any, tb: typing.Any
+    ) -> None:
+        if exc_type is None:
+            self._smbconf.transaction_commit()
+            return
+        return self._smbconf.transaction_cancel()
+
+    def __getitem__(self, name: str) -> list[tuple[str, str]]:
+        try:
+            n2, values = self._smbconf.get_share(name)
+        except _smbconf().SMBConfError as err:
+            if err.error_code == _smbconf().SBC_ERR_NO_SUCH_SERVICE:
+                raise KeyError(name)
+            raise
+        if name != n2:
+            raise ValueError(f"section name invalid: {name!r} != {n2!r}")
+        return values
+
+    def __setitem__(self, name: str, value: list[tuple[str, str]]) -> None:
+        try:
+            self._smbconf.delete_share(name)
+        except _smbconf().SMBConfError as err:
+            if err.error_code != _smbconf().SBC_ERR_NO_SUCH_SERVICE:
+                raise
+        self._smbconf.create_set_share(name, value)
+
+    def __iter__(self) -> typing.Iterator[str]:
+        return iter(self._smbconf.share_names())
+
+    def import_smbconf(
+        self, src: ConfigStore, batch_size: typing.Optional[int] = 100
+    ) -> None:
+        """Import content from one SMBConf configuration object into the
+        current SMBConf configuration object.
+
+        Set batch_size to the maximum number of "shares" to import in one
+        transaction. Set batch_size to None to use only one transaction.
+        """
+        if not self.writeable:
+            raise ValueError("SMBConf is not writable")
+        if batch_size is None:
+            return self._import_smbconf_all(src)
+        return self._import_smbconf_batched(src, batch_size)
+
+    def _import_smbconf_all(self, src: ConfigStore) -> None:
+        with self:
+            for sname in src:
+                self[sname] = src[sname]
+
+    def _import_smbconf_batched(
+        self, src: ConfigStore, batch_size: int
+    ) -> None:
+        # based on a comment in samba's source code for the net command
+        # only import N 'shares' at a time so that the transaction does
+        # not exceed talloc memory limits
+        def _batch_keyfunc(item: tuple[int, str]) -> int:
+            return item[0] // batch_size
+
+        for _, snames in itertools.groupby(enumerate(src), _batch_keyfunc):
+            with self:
+                for _, sname in snames:
+                    self[sname] = src[sname]

--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,4 +1,4 @@
-ARG SAMBACC_BASE_IMAGE='registry.fedoraproject.org/fedora:36'
+ARG SAMBACC_BASE_IMAGE='registry.fedoraproject.org/fedora:37'
 FROM $SAMBACC_BASE_IMAGE
 
 

--- a/tests/test_addc.py
+++ b/tests/test_addc.py
@@ -1,0 +1,147 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2022  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import os
+
+import pytest
+
+
+import sambacc.addc
+
+
+def _fake_samba_tool(path):
+    fake_samba_tool = path / "fake_samba_tool.sh"
+    with open(fake_samba_tool, "w") as fh:
+        fh.write("#!/bin/sh\n")
+        fh.write(f"[ -e {path}/fail ] && exit 1\n")
+        fh.write(f'echo "$@" > {path}/args.out\n')
+        fh.write("exit 0")
+    os.chmod(fake_samba_tool, 0o700)
+    return fake_samba_tool
+
+
+def test_provision(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.provision("FOOBAR.TEST", "quux", "h4ckm3")
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "--realm=FOOBAR.TEST" in result
+    assert "--option=netbios name=quux" in result
+    assert "--dns-backend=SAMBA_INTERNAL" in result
+
+    sambacc.addc.provision(
+        "BARFOO.TEST",
+        "quux",
+        "h4ckm3",
+        options=[
+            ("ldap server require strong auth", "no"),
+            ("dns zone scavenging", "yes"),
+            ("ldap machine suffix", "ou=Machines"),
+            ("netbios name", "flipper"),
+        ],
+    )
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "--realm=BARFOO.TEST" in result
+    assert "--option=netbios name=quux" in result
+    assert "--dns-backend=SAMBA_INTERNAL" in result
+    assert "--option=ldap server require strong auth=no" in result
+    assert "--option=dns zone scavenging=yes" in result
+    assert "--option=ldap machine suffix=ou=Machines" in result
+    assert "--option=netbios name=flipper" not in result
+
+    open(tmp_path / "fail", "w").close()
+    with pytest.raises(Exception):
+        sambacc.addc.provision("FOOBAR.TEST", "quux", "h4ckm3")
+
+
+def test_join(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.join("FOOBAR.TEST", "quux", "h4ckm3")
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "FOOBAR.TEST" in result
+    assert "--option=netbios name=quux" in result
+    assert "--dns-backend=SAMBA_INTERNAL" in result
+
+    sambacc.addc.join(
+        "BARFOO.TEST",
+        "quux",
+        "h4ckm3",
+        options=[
+            ("ldap server require strong auth", "no"),
+            ("dns zone scavenging", "yes"),
+            ("ldap machine suffix", "ou=Machines"),
+            ("netbios name", "flipper"),
+        ],
+    )
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "BARFOO.TEST" in result
+    assert "--option=netbios name=quux" in result
+    assert "--dns-backend=SAMBA_INTERNAL" in result
+    assert "--option=ldap server require strong auth=no" in result
+    assert "--option=dns zone scavenging=yes" in result
+    assert "--option=ldap machine suffix=ou=Machines" in result
+    assert "--option=netbios name=flipper" not in result
+
+
+def test_create_user(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.create_user("fflintstone", "b3dr0ck", "Flintstone", "Fred")
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "user create fflintstone" in result
+    assert "--surname=Flintstone" in result
+    assert "--given-name=Fred" in result
+
+
+def test_create_group(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.create_group("quarry_workers")
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "group add quarry_workers" in result
+
+
+def test_add_group_members(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        sambacc.samba_cmds, "_GLOBAL_PREFIX", [_fake_samba_tool(tmp_path)]
+    )
+
+    sambacc.addc.add_group_members(
+        "quarry_workers", ["fflintstone", "brubble"]
+    )
+    with open(tmp_path / "args.out") as fh:
+        result = fh.read()
+    assert "group addmembers quarry_workers" in result
+    assert "fflintstone,brubble" in result

--- a/tests/test_smbconf_api.py
+++ b/tests/test_smbconf_api.py
@@ -1,0 +1,77 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2023  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import io
+
+import sambacc.smbconf_api
+
+
+def test_simple_config_store():
+    scs = sambacc.smbconf_api.SimpleConfigStore()
+    assert scs.writeable, "SimpleConfigStore should always be writeable"
+    scs["foo"] = [("a", "Artichoke"), ("b", "Broccoli")]
+    scs["bar"] = [("example", "yes"), ("production", "no")]
+    assert list(scs) == ["foo", "bar"]
+    assert scs["foo"] == [("a", "Artichoke"), ("b", "Broccoli")]
+    assert scs["bar"] == [("example", "yes"), ("production", "no")]
+
+
+def test_simple_config_store_import():
+    a = sambacc.smbconf_api.SimpleConfigStore()
+    b = sambacc.smbconf_api.SimpleConfigStore()
+    a["foo"] = [("a", "Artichoke"), ("b", "Broccoli")]
+    b["bar"] = [("example", "yes"), ("production", "no")]
+    assert list(a) == ["foo"]
+    assert list(b) == ["bar"]
+
+    a.import_smbconf(b)
+    assert list(a) == ["foo", "bar"]
+    assert list(b) == ["bar"]
+    assert a["bar"] == [("example", "yes"), ("production", "no")]
+
+    b["baz"] = [("quest", "one")]
+    b["bar"] = [("example", "no"), ("production", "no"), ("unittest", "yes")]
+    a.import_smbconf(b)
+
+    assert list(a) == ["foo", "bar", "baz"]
+    assert a["bar"] == [
+        ("example", "no"),
+        ("production", "no"),
+        ("unittest", "yes"),
+    ]
+    assert a["baz"] == [("quest", "one")]
+
+
+def test_write_store_as_smb_conf():
+    scs = sambacc.smbconf_api.SimpleConfigStore()
+    scs["foo"] = [("a", "Artichoke"), ("b", "Broccoli")]
+    scs["bar"] = [("example", "yes"), ("production", "no")]
+    scs["global"] = [("first", "1"), ("second", "2")]
+    fh = io.StringIO()
+    sambacc.smbconf_api.write_store_as_smb_conf(fh, scs)
+    res = fh.getvalue().splitlines()
+    assert res[0] == ""
+    assert res[1] == "[global]"
+    assert res[2] == "\tfirst = 1"
+    assert res[3] == "\tsecond = 2"
+    assert "[foo]" in res
+    assert "\ta = Artichoke" in res
+    assert "\tb = Broccoli" in res
+    assert "[bar]" in res
+    assert "\texample = yes" in res
+    assert "\tproduction = no" in res

--- a/tests/test_smbconf_samba.py
+++ b/tests/test_smbconf_samba.py
@@ -1,0 +1,188 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2023  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import pytest
+
+import sambacc.smbconf_api
+import sambacc.smbconf_samba
+
+smb_conf_reg_stub = """
+[global]
+cache directory = {path}
+state directory = {path}
+private dir = {path}
+include = registry
+"""
+
+smb_conf_sample = """
+[global]
+  realm = my.kingdom.fora.horse
+
+[share_a]
+  path = /foo/bar/baz
+  read only = no
+[share_b]
+  path = /foo/x/b
+  read only = no
+[share_c]
+  path = /foo/x/c
+  read only = no
+[share_d]
+  path = /foo/x/d
+  read only = no
+[share_e]
+  path = /foo/x/e
+  read only = no
+"""
+
+
+def _import_probe():
+    try:
+        import samba.smbconf  # type: ignore
+        import samba.samba3.smbconf  # type: ignore # noqa
+    except ImportError:
+        pytest.skip("unable to load samba smbconf modules")
+
+
+def _smb_data(path, smb_conf_text):
+    data_path = path / "_samba"
+    data_path.mkdir()
+    smb_conf_path = path / "smb.conf"
+    smb_conf_path.write_text(smb_conf_text.format(path=data_path))
+    return smb_conf_path
+
+
+@pytest.fixture(scope="session")
+def smbconf_reg_once(tmp_path_factory):
+    _import_probe()
+    tmp_path = tmp_path_factory.mktemp("smb_reg")
+    smb_conf_path = _smb_data(tmp_path, smb_conf_reg_stub)
+
+    return sambacc.smbconf_samba.SMBConf.from_registry(str(smb_conf_path))
+
+
+@pytest.fixture(scope="function")
+def smbconf_reg(smbconf_reg_once):
+    # IMPORTANT: Reminder, samba doesn't release the registry db once opened.
+    smbconf_reg_once._smbconf.drop()
+    return smbconf_reg_once
+
+
+@pytest.fixture(scope="function")
+def smbconf_file(tmp_path):
+    _import_probe()
+    smb_conf_path = _smb_data(tmp_path, smb_conf_sample)
+
+    return sambacc.smbconf_samba.SMBConf.from_file(str(smb_conf_path))
+
+
+def test_smbconf_file_read(smbconf_file):
+    assert smbconf_file["global"] == [("realm", "my.kingdom.fora.horse")]
+    assert smbconf_file["share_a"] == [
+        ("path", "/foo/bar/baz"),
+        ("read only", "no"),
+    ]
+    with pytest.raises(KeyError):
+        smbconf_file["not_there"]
+    assert list(smbconf_file) == [
+        "global",
+        "share_a",
+        "share_b",
+        "share_c",
+        "share_d",
+        "share_e",
+    ]
+
+
+def test_smbconf_write(smbconf_file):
+    assert not smbconf_file.writeable
+    with pytest.raises(Exception):
+        smbconf_file.import_smbconf(sambacc.smbconf_api.SimpleConfigStore())
+
+
+def test_smbconf_reg_write_read(smbconf_reg):
+    assert smbconf_reg.writeable
+    assert list(smbconf_reg) == []
+    smbconf_reg["global"] = [("test:one", "1"), ("test:two", "2")]
+    assert smbconf_reg["global"] == [("test:one", "1"), ("test:two", "2")]
+    smbconf_reg["global"] = [("test:one", "1"), ("test:two", "22")]
+    assert smbconf_reg["global"] == [("test:one", "1"), ("test:two", "22")]
+
+
+def test_smbconf_reg_write_txn_read(smbconf_reg):
+    assert smbconf_reg.writeable
+    assert list(smbconf_reg) == []
+    with smbconf_reg:
+        smbconf_reg["global"] = [("test:one", "1"), ("test:two", "2")]
+    assert smbconf_reg["global"] == [("test:one", "1"), ("test:two", "2")]
+    with smbconf_reg:
+        smbconf_reg["global"] = [("test:one", "1"), ("test:two", "22")]
+    assert smbconf_reg["global"] == [("test:one", "1"), ("test:two", "22")]
+
+    # transaction with error
+    with pytest.raises(ValueError):
+        with smbconf_reg:
+            smbconf_reg["global"] = [("test:one", "1"), ("test:two", "2222")]
+            raise ValueError("foo")
+    assert smbconf_reg["global"] == [("test:one", "1"), ("test:two", "22")]
+
+    # no transaction with error
+    with pytest.raises(ValueError):
+        smbconf_reg["global"] = [("test:one", "1"), ("test:two", "2222")]
+        raise ValueError("foo")
+    assert smbconf_reg["global"] == [("test:one", "1"), ("test:two", "2222")]
+
+
+def test_smbconf_reg_import_batched(smbconf_reg, smbconf_file):
+    assert list(smbconf_reg) == []
+    smbconf_reg.import_smbconf(smbconf_file, batch_size=4)
+    assert smbconf_reg["global"] == [("realm", "my.kingdom.fora.horse")]
+    assert smbconf_reg["share_a"] == [
+        ("path", "/foo/bar/baz"),
+        ("read only", "no"),
+    ]
+    with pytest.raises(KeyError):
+        smbconf_reg["not_there"]
+    assert list(smbconf_reg) == [
+        "global",
+        "share_a",
+        "share_b",
+        "share_c",
+        "share_d",
+        "share_e",
+    ]
+
+
+def test_smbconf_reg_import_unbatched(smbconf_reg, smbconf_file):
+    assert list(smbconf_reg) == []
+    smbconf_reg.import_smbconf(smbconf_file, batch_size=None)
+    assert smbconf_reg["global"] == [("realm", "my.kingdom.fora.horse")]
+    assert smbconf_reg["share_a"] == [
+        ("path", "/foo/bar/baz"),
+        ("read only", "no"),
+    ]
+    with pytest.raises(KeyError):
+        smbconf_reg["not_there"]
+    assert list(smbconf_reg) == [
+        "global",
+        "share_a",
+        "share_b",
+        "share_c",
+        "share_d",
+        "share_e",
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ deps =
     dnspython
     -e .[validation,yaml,toml]
 commands =
-    py.test -v tests --cov=sambacc --cov-report=html {posargs}
+    py.test -v --cov=sambacc --cov-report=html {posargs:tests}
 
 [testenv:{py3,py39}-mypy]
 deps =


### PR DESCRIPTION
This revisits and reuses parts of the work done in #45
Fixes: #43 

When replying to samba-in-kubernetes/samba-container#154 I realized that one of the workarounds I suggested could be implemented in sambacc without too many complications and without needing to change `samba-tool`. Also, all versions of samba used by samba-container images that provide AD DC images should be providing the smbconf python library now. This avoids us having to parse smb.conf-style-ini in python.

Briefly, when an AD DC configuration provides globals references the global options are passed directory to samba-tool commands and after samba-tool has generated an smb.conf, sambacc uses smbconf libraries to read the smb.conf, merge the settings from the sambacc globals and write out an updated smb.conf file.

An example YAML configuration file I manually tested with:
```yaml
samba-container-config: v0
configs:
  demo:
    instance_features: [addc]
    domain_settings: sink
    instance_name: dc1
    globals: ["adglobals"]
domain_settings:
  sink:
    realm: DOMAIN2.SINK.TEST
    short_domain: DOMAIN2
    admin_password: Passw0rd
domain_groups:
  sink:
    - name: peeps
domain_users:
  sink:
    - name: bwayne
      password: "1115Rose."
      given_name: Bruce
      surname: Wayne
      member_of: ["peeps"]
globals:
  adglobals:
    options:
      "dns forwarder": "192.168.64.1"
      "ldap server require strong auth": "no"
      "ignore:me": "yes"
```

Results in an smb.conf like:
```
[global]
        dns forwarder = 192.168.64.1
        netbios name = dc1
        realm = DOMAIN2.SINK.TEST
        server role = active directory domain controller
        workgroup = DOMAIN2
        idmap_ldb:use rfc2307 = yes
        ignore:me = yes
        ldap server require strong auth = no

[sysvol]
        path = /var/lib/samba/sysvol
        read only = No

[netlogon]
        path = /var/lib/samba/sysvol/domain2.sink.test/scripts
        read only = No
```


Using `dig` in the container I was able to test that `dns forwarder` option did have an actual effect on the running `samba` server.

---

The PR starts off with a few random cleanups of stuff that I hit while working on these changes. If you'd rather see those as a separate PR, just ask.


This doesn't update any docs. I will update the documentation in a separate PR, perhaps after asking the issue reporters to test out the changes when they land in samba-container server & ad-server latest images on quay.