### PR TITLE
docs: add a link to the pypi repository for sambacc to release doc

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -74,9 +74,10 @@ publish the release.
 
 ## PyPI
 
-There is a sambacc repository on PyPI. This exists mainly to reserve the
-sambacc name, however we desire to keep it up to date too.
-You will need to have a PyPI account and access to the sambacc repo.
+There is a [sambacc repository on PyPI](https://pypi.org/project/sambacc/).
+This exists mainly to reserve the sambacc name, however we desire to keep it up
+to date too.  You will need to have a PyPI account and access to the sambacc
+repo.
 
 Log into PyPI web UI. (Re)Generate a pypi login token for sambacc.
 Ensure `twine` is installed:


### PR DESCRIPTION
The PyPI sambacc repo is mainly a "space saver" to reserve the name, however it's best to keep it up to date and so the doc shouldn't make you guess as to the url for the repo.