### PR TITLE
setup.cfg: fix missing description text

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,8 @@ author_email = phlogistonjohn@asynchrono.us
 readme = file: README.md
 url = https://github.com/samba-in-kubernetes/sambacc
 license = GPL3
+long_description = file: README.md
+long_description_content_type = text/markdown
 
 [options]
 packages = sambacc, sambacc.commands, sambacc.schema


### PR DESCRIPTION
Fix the `twine check` errors and missing text on pypi for sambacc.