### PR TITLE
commands: pass opener to read_config_files called from update-config

### DIFF
--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -73,7 +73,9 @@ def _update_config_args(parser: argparse.ArgumentParser) -> None:
 def _read_config(ctx: Context) -> config.InstanceConfig:
     cfgs = ctx.cli.config or []
     return config.read_config_files(
-        cfgs, require_validation=ctx.require_validation
+        cfgs,
+        require_validation=ctx.require_validation,
+        opener=ctx.opener,
     ).get(ctx.cli.identity)
 
 

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -21,6 +21,7 @@ import functools
 import os
 
 import sambacc.config
+import sambacc.opener
 import sambacc.paths
 
 import sambacc.commands.config
@@ -112,6 +113,10 @@ class FakeContext:
             sambacc.config.read_config_files(config).get(identity),
         )
         return ctx
+
+    @property
+    def opener(self) -> sambacc.opener.Opener:
+        return sambacc.opener.FileOpener()
 
 
 class FakeWaiter:


### PR DESCRIPTION
Fix issue using remote resources in update-config command by passing the opener to read_config_files call.