### PR TITLE
container: update default test container version to fedora 39

### DIFF
--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,4 +1,4 @@
-ARG SAMBACC_BASE_IMAGE='registry.fedoraproject.org/fedora:37'
+ARG SAMBACC_BASE_IMAGE='registry.fedoraproject.org/fedora:39'
 FROM $SAMBACC_BASE_IMAGE
 
 


### PR DESCRIPTION
Fedora 37 is EOL. Update the default version of the test container to use the current fedora release.