### PR TITLE
sambacc: add support for selecting ceph auth user/entity/id when reading config

### DIFF
--- a/sambacc/commands/main.py
+++ b/sambacc/commands/main.py
@@ -118,6 +118,11 @@ def global_args(parser: Parser) -> None:
             " Pass `?` for more details)."
         ),
     )
+    parser.add_argument(
+        "--debug",
+        action="store_true",
+        help="Enable debug level logging of sambacc.",
+    )
 
 
 def _ceph_id(
@@ -293,13 +298,14 @@ def pre_action(cli: typing.Any) -> None:
 
 
 def enable_logging(cli: typing.Any) -> None:
+    level = logging.DEBUG if cli.debug else logging.INFO
     logger = logging.getLogger()
-    logger.setLevel(logging.INFO)
+    logger.setLevel(level)
     handler = logging.StreamHandler()
     handler.setFormatter(
         logging.Formatter("{asctime}: {levelname}: {message}", style="{")
     )
-    handler.setLevel(logging.INFO)
+    handler.setLevel(level)
     logger.addHandler(handler)
 
 

--- a/sambacc/rados_opener.py
+++ b/sambacc/rados_opener.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import io
 import json
+import logging
 import typing
 import urllib.request
 
@@ -30,6 +31,8 @@ _RADOSModule = typing.Any
 _RADOSObject = typing.Any
 
 _CHUNK_SIZE = 4 * 1024
+
+_logger = logging.getLogger(__name__)
 
 
 class RADOSUnsupported(Exception):
@@ -47,6 +50,7 @@ class _RADOSInterface:
             name = self.client_name
         else:
             rados_id = self.client_name
+        _logger.debug("Creating RADOS connection")
         return self.api.Rados(
             name=name,
             rados_id=rados_id,
@@ -232,8 +236,13 @@ def enable_rados_url_opener(
     try:
         import rados  # type: ignore[import]
     except ImportError:
+        _logger.debug("Failed to import ceph 'rados' module")
         return
 
+    _logger.debug(
+        "Enabling ceph rados support with"
+        f" client_name={client_name!r}, full_name={full_name}"
+    )
     rados_interface = _RADOSInterface()
     rados_interface.api = rados
     rados_interface.client_name = client_name

--- a/tox.ini
+++ b/tox.ini
@@ -57,10 +57,18 @@ commands =
 
 [testenv:schemacheck]
 deps =
-    black
+    black>=21.8b0, <23.11
     PyYAML
 commands =
     python -m sambacc.schema.tool
+# The following env var is a workaround for running this testenv on fedora 39
+# with python 3.12.1. As of approx. 2023-12-11 the ci started # to fail because
+# of the multidict library (not even one of our direct dependencies) failing
+# to install from source because we (intentionally) have no C compiler in the
+# image. Try to remove this in a few weeks to see if wheel availability or
+# whatever has been resolved.
+setenv =
+    MULTIDICT_NO_EXTENSIONS=1
 
 # this gitlint rule is not run by default.
 # Run it manually with: tox -e gitlint

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ allowlist_externals =
 [testenv:formatting]
 deps =
     flake8
-    black>=21.8b0
+    black>=21.8b0, <23.11
 commands =
     flake8 sambacc tests
     black --check -v .


### PR DESCRIPTION
Add a command line option --ceph-id and environment variable SAMBACC_CEPH_ID that allow one to specify the user/id/entity name (ceph is really inconsistent about what to call these IMO) that should be used to read the config. Annoyingly, ceph libraries default to using the admin user with maximum capabilities and so it's critical to remember to get this working for non-admin users - as this PR tries to do. 

The value provided to --ceph-id / SAMBACC_CEPH_ID can be either just the name string (like: `bob` or `client.bob`) or a key value pair like `name=client.bob`. The former is implemented for convenience but ceph tooling can be a bit ambiguous about if it expects/provides the prefixed (`client.`) or unprefixed form of names. The key-value form allows one to more precisely state if the name is "fully qualified" (`name=client.bob`) or not (`rados_id=bob`). The plain name-only form has to guess and just assumes anything starting with `client.` is already fully-qualified.

While I was working on this I hit <s>two</s> three additional items:
* First, there was no way for me to turn on debug logging so I added a --debug cli option.
* Second, there seems to be a behavior change in the newer version(s) of `black` so I temporarily capped the maximum version so it doesn't fail the CI on files that we haven't changed. In a future PR I will revisist this and fix things up in a nicer way.
* IIIrd, schemacheck on f39 would not run due to an indirect dep failing to install. Added a workaround