### PR TITLE
explicitly use black version from 2023

### DIFF
--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -66,7 +66,7 @@ def _update_config_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--watch",
         action="store_true",
-        help=("If set, watch the source for changes and update config."),
+        help="If set, watch the source for changes and update config.",
     )
 
 

--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -57,19 +57,19 @@ def _ctdb_migrate_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--dest-dir",
         default=ctdb.DB_DIR,
-        help=("Specify where CTDB database files will be written."),
+        help="Specify where CTDB database files will be written.",
     )
 
 
 def _ctdb_general_node_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--hostname",
-        help=("Specify the host name for the CTDB node"),
+        help="Specify the host name for the CTDB node",
     )
     parser.add_argument(
         "--node-number",
         type=int,
-        help=("Expected node number"),
+        help="Expected node number",
     )
     # This is a choice with a single acceptable param, rather than an on/off
     # bool, # in the case that other container orchs have a similar but not
@@ -84,7 +84,7 @@ def _ctdb_general_node_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--persistent-path",
-        help=("Path to a persistent path for storing nodes file"),
+        help="Path to a persistent path for storing nodes file",
     )
 
 
@@ -92,7 +92,7 @@ def _ctdb_set_node_args(parser: argparse.ArgumentParser) -> None:
     _ctdb_general_node_args(parser)
     parser.add_argument(
         "--ip",
-        help=("Specify node by IP"),
+        help="Specify node by IP",
     )
 
 

--- a/sambacc/commands/dns.py
+++ b/sambacc/commands/dns.py
@@ -32,18 +32,18 @@ def _dns_register_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--watch",
         action="store_true",
-        help=("If set, watch the source for changes and update DNS."),
+        help="If set, watch the source for changes and update DNS.",
     )
     parser.add_argument(
         "--domain",
         default="",
-        help=("Manually specify parent domain for DNS entries."),
+        help="Manually specify parent domain for DNS entries.",
     )
     parser.add_argument(
         "--target",
         default=container_dns.EXTERNAL,
         choices=[container_dns.EXTERNAL, container_dns.INTERNAL],
-        help=("Register IPs that fulfill the given access target."),
+        help="Register IPs that fulfill the given access target.",
     )
     parser.add_argument("source", help="Path to source JSON file.")
 

--- a/sambacc/commands/main.py
+++ b/sambacc/commands/main.py
@@ -101,12 +101,12 @@ def global_args(parser: Parser) -> None:
     parser.add_argument(
         "--skip-if-file",
         action="append",
-        help=("Perform no action if the specified path exists."),
+        help="Perform no action if the specified path exists.",
     )
     parser.add_argument(
         "--validate-config",
         choices=("auto", "required", "true", "false"),
-        help=("Perform schema based validation of configuration."),
+        help="Perform schema based validation of configuration.",
     )
     parser.add_argument(
         "--ceph-id",

--- a/tox.ini
+++ b/tox.ini
@@ -50,14 +50,14 @@ allowlist_externals =
 [testenv:formatting]
 deps =
     flake8
-    black>=21.8b0, <23.11
+    black>=23, <24
 commands =
     flake8 sambacc tests
     black --check -v .
 
 [testenv:schemacheck]
 deps =
-    black>=21.8b0, <23.11
+    black>=23, <24
     PyYAML
 commands =
     python -m sambacc.schema.tool


### PR DESCRIPTION
The CI was failing recently due to is (somehow) using the black 24 alpha. This was hackily fixed in PR #98 and this PR more cleanly pins the project to use black's 2023 style for now.

I did find some obvious cleanups using the --preview (2024) style and took them in the other change in this pr. However, I'm not planning to commit to the 2024 style until understand better why it is "messing up" some of the protocol function definitions. 