### PR TITLE
tox.ini: add schemaupdate environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -70,6 +70,13 @@ commands =
 setenv =
     MULTIDICT_NO_EXTENSIONS=1
 
+[testenv:schemaupdate]
+deps =
+    black>=23, <24
+    PyYAML
+commands =
+    python -m sambacc.schema.tool --update
+
 # this gitlint rule is not run by default.
 # Run it manually with: tox -e gitlint
 [testenv:gitlint]


### PR DESCRIPTION
Run `tox -e schemaupdate` to regenerate the schema file(s).

This complements the existing read-only schemacheck environment with a read-write env.