### PR TITLE
addc: dynamic interface filtering for provisioning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -259,6 +259,35 @@ Each domain configuration section is as follows:
 * `realm` - Name of the domain in kerberos realm form.
 * `short_domain` - Optional. The short (nt-style) name of the domain.
 * `admin_password` - The default password for the administrator user.
+* `interfaces` - An optional subsection for dynamically configuring the network
+  interfaces the domain controller will use. See below.
+
+#### Interfaces Section
+
+The interfaces section enables the sambacc tool to dynamically configure what
+network interfaces will be enabled when the domain is provisioned.  On some
+systems and in some environments there may be "bogus" network interfaces that
+one does not want to enable the domain controller for. Examples include
+interfaces related to virtualization or container engines that would cause the
+DC to include a private or otherwise inaccessable IP to be included in the DNS
+record(s) for the domain & domain controller.
+
+The loopback device ("lo") is always enabled.
+
+* `include_pattern` - Optional string. A regular expression that must match
+  the name of an interface for that interface to be included.
+  Example: `^eno[0-9]+$`
+* `exclude_pattern` - Optional string. A regular expression that must not
+  match the name of an interface for that interface to be included.
+  The `exclude_pattern` option takes precedence over the `include_pattern`
+  option.
+  Example: `^(docker|virbr)[0-9]+$`
+
+These options are intended to automate the act of examining a host's interfaces
+prior to deployment and creating a list of suitable interfaces prior to setting
+the "interfaces" and "bind interfaces only" parameters.  See the [Samba
+Wiki page](https://wiki.samba.org/index.php/Setting_up_Samba_as_an_Active_Directory_Domain_Controller#Parameter_Reference)
+for more details on this operation.
 
 
 ## Domain Groups Section

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -507,7 +507,19 @@ class DomainConfig:
         self.realm = drec["realm"]
         self.short_domain = drec.get("short_domain", "")
         self.admin_password = drec.get("admin_password", "")
+        self.interface_config = DCInterfaceConfig(drec.get("interfaces", {}))
         self.dcname = instance_name
+
+
+class DCInterfaceConfig:
+    def __init__(self, iface_config: dict) -> None:
+        self.include_pattern: str = iface_config.get("include_pattern", "")
+        self.exclude_pattern: str = iface_config.get("exclude_pattern", "")
+
+    @property
+    def configured(self) -> bool:
+        """Return true if at least one interface property has been set."""
+        return bool(self.include_pattern) or bool(self.exclude_pattern)
 
 
 class DomainUserEntry(UserEntry):

--- a/sambacc/schema/conf-v0.schema.json
+++ b/sambacc/schema/conf-v0.schema.json
@@ -256,6 +256,19 @@
           },
           "admin_password": {
             "type": "string"
+          },
+          "interfaces": {
+            "type": "object",
+            "properties": {
+              "include_pattern": {
+                "type": "string",
+                "description": "A regular expression that must match for a system interface\nto be included in the AD DC interfaces list.\n"
+              },
+              "exclude_pattern": {
+                "type": "string",
+                "description": "A regular expression that must not match for a system interface\nto be included in the AD DC interfaces list.\n"
+              }
+            }
           }
         },
         "required": [

--- a/sambacc/schema/conf-v0.schema.yaml
+++ b/sambacc/schema/conf-v0.schema.yaml
@@ -249,6 +249,19 @@ properties:
           type: string
         admin_password:
           type: string
+        interfaces:
+          type: object
+          properties:
+            include_pattern:
+              type: string
+              description: |
+                A regular expression that must match for a system interface
+                to be included in the AD DC interfaces list.
+            exclude_pattern:
+              type: string
+              description: |
+                A regular expression that must not match for a system interface
+                to be included in the AD DC interfaces list.
       required:
         - realm
       additionalProperties: false

--- a/sambacc/schema/conf_v0_schema.py
+++ b/sambacc/schema/conf_v0_schema.py
@@ -274,6 +274,27 @@ SCHEMA = {
                     "realm": {"type": "string"},
                     "short_domain": {"type": "string"},
                     "admin_password": {"type": "string"},
+                    "interfaces": {
+                        "type": "object",
+                        "properties": {
+                            "include_pattern": {
+                                "type": "string",
+                                "description": (
+                                    "A regular expression that must match for"
+                                    " a system interface\nto be included in"
+                                    " the AD DC interfaces list.\n"
+                                ),
+                            },
+                            "exclude_pattern": {
+                                "type": "string",
+                                "description": (
+                                    "A regular expression that must not match"
+                                    " for a system interface\nto be included"
+                                    " in the AD DC interfaces list.\n"
+                                ),
+                            },
+                        },
+                    },
                 },
                 "required": ["realm"],
                 "additionalProperties": False,


### PR DESCRIPTION
Lately I keep hitting hosts that have "bogus" interfaces, stuff like "docker0" that are not suitable for including in the DNS records of the DC. While one could configuring these statically if you know all "good" interfaces ahead of time I keep bumping into the fact that I don't - nor do I want to carefully examine every host. What I do know is stuff like `docker0` or `virbirX` are often not suitable.

Thus I'm adding some new options for the domain_settings section. Under the domain one can have "interfaces" and interfaces can contain any of "include_pattern" and "exclude_pattern". Both take regexes and filter as they are named.  This way I can just start doing stuff like setting:

```
  "domain_settings": {
    "sink": {
      "realm": "DOMAIN1.SINK.TEST",
      "short_domain": "DOMAIN1",
      "admin_password": "Passw0rd",
      "interfaces": {
            "exclude_pattern": "^(virbr|docker).*$"
        }
    } 
  }, 
```

Interfaces is a subsection because I thought it looked neater and I figured there's a chance we'll want to extend the ways we filter interfaces in the future so it made sense to encapsulate it a bit.