### PR TITLE
schema: improve wording in interfaces description field

### DIFF
--- a/sambacc/schema/conf-v0.schema.json
+++ b/sambacc/schema/conf-v0.schema.json
@@ -262,11 +262,11 @@
             "properties": {
               "include_pattern": {
                 "type": "string",
-                "description": "A regular expression that must match for a system interface\nto be included in the AD DC interfaces list.\n"
+                "description": "A regular expression that must match for a network interface\nto be included in the AD DC interfaces list.\n"
               },
               "exclude_pattern": {
                 "type": "string",
-                "description": "A regular expression that must not match for a system interface\nto be included in the AD DC interfaces list.\n"
+                "description": "A regular expression that must not match for a network interface\nto be included in the AD DC interfaces list.\n"
               }
             }
           }

--- a/sambacc/schema/conf-v0.schema.yaml
+++ b/sambacc/schema/conf-v0.schema.yaml
@@ -255,12 +255,12 @@ properties:
             include_pattern:
               type: string
               description: |
-                A regular expression that must match for a system interface
+                A regular expression that must match for a network interface
                 to be included in the AD DC interfaces list.
             exclude_pattern:
               type: string
               description: |
-                A regular expression that must not match for a system interface
+                A regular expression that must not match for a network interface
                 to be included in the AD DC interfaces list.
       required:
         - realm

--- a/sambacc/schema/conf_v0_schema.py
+++ b/sambacc/schema/conf_v0_schema.py
@@ -281,7 +281,7 @@ SCHEMA = {
                                 "type": "string",
                                 "description": (
                                     "A regular expression that must match for"
-                                    " a system interface\nto be included in"
+                                    " a network interface\nto be included in"
                                     " the AD DC interfaces list.\n"
                                 ),
                             },
@@ -289,7 +289,7 @@ SCHEMA = {
                                 "type": "string",
                                 "description": (
                                     "A regular expression that must not match"
-                                    " for a system interface\nto be included"
+                                    " for a network interface\nto be included"
                                     " in the AD DC interfaces list.\n"
                                 ),
                             },


### PR DESCRIPTION
Thanks to @anoopcs9 for pointing out some potentially confusing wording in the previous patches adding interfaces options include_pattern & exclude_pattern. Change 'system interfaces' to 'network interfaces'.