### PR TITLE
workflows: upgrade to checkout@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
@@ -36,7 +36,7 @@ jobs:
           - test_distro: "centos-stream9"
             base_image: "quay.io/centos/centos:stream9"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Build test container
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'samba-in-kubernetes/sambacc'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: log in to quay.io
         run: docker login -u "${{ secrets.QUAY_USER }}" -p "${{ secrets.QUAY_PASS }}" quay.io
       - name: build container image


### PR DESCRIPTION
Eliminate github's warning ("Node.js 16 actions are deprecated") by upgrading to 'checkout@v4'.