### PR TITLE
workflows: disable fail-fast option for distro matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         test_distro: ["fedora-39", "fedora-38", "centos-stream9"]
         include:


### PR DESCRIPTION
There's a consistent failure on the f38 build that causes the other builds to terminate early. Unset the fail-fast option to allow the other jobs to run while we investigate the failure and/or wait for f40.