### PR TITLE
workflows: update text matrix to use fedora 40

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -16,7 +16,7 @@ queue_rules:
     conditions:
       - check-success=check-commits
       - check-success=test (fedora-39)
-      - check-success=test (fedora-38)
+      - check-success=test (fedora-40)
       - check-success=test (centos-stream9)
       - check-success=dpulls
 
@@ -35,7 +35,7 @@ pull_request_rules:
     conditions:
       - check-success=check-commits
       - check-success=test (fedora-39)
-      - check-success=test (fedora-38)
+      - check-success=test (fedora-40)
       - check-success=test (centos-stream9)
       - check-success=dpulls
       - "-draft"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_distro: ["fedora-39", "fedora-38", "centos-stream9"]
+        test_distro: ["fedora-40", "fedora-39", "centos-stream9"]
         include:
+          - test_distro: "fedora-40"
+            base_image: "registry.fedoraproject.org/fedora:40"
           - test_distro: "fedora-39"
             base_image: "registry.fedoraproject.org/fedora:39"
-          - test_distro: "fedora-38"
-            base_image: "registry.fedoraproject.org/fedora:38"
           - test_distro: "centos-stream9"
             base_image: "quay.io/centos/centos:stream9"
     steps:


### PR DESCRIPTION
Fedora 40 has been out for a few weeks. Update the test matrix to remove
the EOL fedora 38 and use fedora 40.