### PR TITLE
commands: add new generic --skip-if command line options 

### DIFF
--- a/sambacc/commands/dcmain.py
+++ b/sambacc/commands/dcmain.py
@@ -19,10 +19,10 @@
 import typing
 
 from . import addc
+from . import skips
 from .cli import Fail
 from .main import (
     CommandContext,
-    action_filter,
     enable_logging,
     env_to_cli,
     global_args,
@@ -41,9 +41,10 @@ def main(args: typing.Optional[typing.Sequence[str]] = None) -> None:
         raise Fail("missing container identity")
 
     pre_action(cli)
-    skip = action_filter(cli)
+    ctx = CommandContext(cli)
+    skip = skips.test(ctx)
     if skip:
-        print(f"Action skipped: {skip}")
+        print(f"Command Skipped: {skip}")
         return
     cfunc = getattr(cli, "cfunc", default_cfunc)
     cfunc(CommandContext(cli))

--- a/sambacc/commands/skips.py
+++ b/sambacc/commands/skips.py
@@ -1,0 +1,187 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2024  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from typing import Optional
+import argparse
+import os
+
+from sambacc.typelets import Self
+
+from .cli import Context
+
+
+class SkipIf:
+    """Base class for objects used to check if a particular sambacc command
+    should be skipped.
+    Skips are useful when different commands are chained together
+    unconditionally in a configuration file (like k8s init containers) but
+    certain commmands should not be run.
+    """
+
+    NAME: str = ""
+
+    def test(self, ctx: Context) -> Optional[str]:
+        """Return a string explaining the reason for the skip or None
+        indicating no skip is desired.
+        """
+        raise NotImplementedError()  # pragma: nocover
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        """Parse a string into a skip class arguments."""
+        raise NotImplementedError()  # pragma: nocover
+
+
+class SkipFile(SkipIf):
+    """Skip execution if a file exists or does not exist.
+    The input value "file:/foo/bar" will trigger a skip if the file /foo/bar
+    exists. To skip if a file does not exist, use "file:!/foo/bar" - prefix the
+    file name with an exclaimation point.
+    """
+
+    NAME: str = "file"
+    inverted: bool = False
+    path: str = ""
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        obj = cls()
+        if not value:
+            raise ValueError("missing path")
+        if value[0] == "!":
+            obj.inverted = True
+            value = value[1:]
+        obj.path = value
+        return obj
+
+    def test(self, ctx: Context) -> Optional[str]:
+        exists = os.path.exists(self.path)
+        if self.inverted and not exists:
+            return f"skip-if-file-missing: {self.path} missing"
+        if not self.inverted and exists:
+            return f"skip-if-file-exists: {self.path} exists"
+        return None
+
+
+class SkipEnv(SkipIf):
+    """Skip execution if an environment variable is, or is not, equal to a
+    value. The specification is roughly "env:<ENV_VAR><op><VALUE>" where op may
+    be either `==` or `!=`. For example, "env:FLAVOR==cherry" will skip
+    execution if the environment variable "FLAVOR" contains the value "cherry".
+    "env:FLAVOR!=cherry" will skip execution if "FLAVOR" contains any value
+    other than "cherry".
+    """
+
+    NAME: str = "env"
+    _EQ = "=="
+    _NEQ = "!="
+
+    def __init__(self, op: str, var_name: str, value: str) -> None:
+        self.op = op
+        self.var_name = var_name
+        self.target_value = value
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        if cls._EQ in value:
+            op = cls._EQ
+        elif cls._NEQ in value:
+            op = cls._NEQ
+        else:
+            raise ValueError("invalid SkipEnv: missing or invalid operation")
+        lhv, rhv = value.split(op, 1)
+        return cls(op, lhv, rhv)
+
+    def test(self, ctx: Context) -> Optional[str]:
+        env_val = os.environ.get(self.var_name)
+        if self.op == self._EQ and env_val == self.target_value:
+            return (
+                f"env var: {self.var_name}"
+                f" -> {env_val} {self.op} {self.target_value}"
+            )
+        if self.op == self._NEQ and env_val != self.target_value:
+            return (
+                f"env var: {self.var_name}"
+                f" -> {env_val} {self.op} {self.target_value}"
+            )
+        return None
+
+
+class SkipAlways(SkipIf):
+    """Skip execution unconditionally. Must be specified as "always:" and takes
+    no value after the colon.
+    """
+
+    NAME: str = "always"
+
+    @classmethod
+    def parse(cls, value: str) -> Self:
+        if value:
+            raise ValueError("always skip takes no value")
+        return cls()
+
+    def test(self, ctx: Context) -> Optional[str]:
+        return "always skip"
+
+
+_SKIP_TYPES = [SkipFile, SkipEnv, SkipAlways]
+
+
+def test(
+    ctx: Context, *, conditions: Optional[list[SkipIf]] = None
+) -> Optional[str]:
+    """Return a string explaining the reason for a skip or None indicating
+    no skip should be performed. Typically the skip conditions will be
+    derived from the command line arguments but can be passed in manually
+    using the `conditions` keyword argument.
+    """
+    if not conditions:
+        conditions = ctx.cli.skip_conditions or []
+    for cond in conditions:
+        skip = cond.test(ctx)
+        if skip:
+            return skip
+    return None
+
+
+def parse(value: str) -> SkipIf:
+    """Given a string return a SkipIf-based object. Every value must be
+    prefixed with the skip "type" (the skip type's NAME).
+    """
+    if value == "?":
+        # A hack to avoid putting tons of documentation into the help output.
+        raise argparse.ArgumentTypeError(_help_info())
+    for sk in _SKIP_TYPES:
+        assert issubclass(sk, SkipIf)
+        prefix = f"{sk.NAME}:"
+        plen = len(prefix)
+        if value.startswith(prefix):
+            return sk.parse(value[plen:])
+    raise KeyError("no matching skip rule for: {value!r}")
+
+
+def _help_info() -> str:
+    msgs = ["Skip conditions help details:", ""]
+    for sk in _SKIP_TYPES:
+        assert issubclass(sk, SkipIf)
+        msgs.append(f"== Skip execution on condition `{sk.NAME}` ==")
+        assert sk.__doc__
+        for line in sk.__doc__.splitlines():
+            msgs.append(line.strip())
+        msgs.append("")
+    return "\n".join(msgs)

--- a/tests/test_skips.py
+++ b/tests/test_skips.py
@@ -1,0 +1,114 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2024  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from unittest import mock
+
+import pytest
+
+from sambacc.commands import skips
+
+
+@pytest.mark.parametrize(
+    "value,rtype",
+    [
+        ("always:", skips.SkipAlways),
+        ("file:/var/lib/womble", skips.SkipFile),
+        ("file:!/var/lib/zomble", skips.SkipFile),
+        ("env:LIMIT==none", skips.SkipEnv),
+        ("env:LIMIT!=everybody", skips.SkipEnv),
+        ("env:LIMIT=everybody", ValueError),
+        ("env:LIMIT", ValueError),
+        ("file:", ValueError),
+        ("always:forever", ValueError),
+        ("klunk:", KeyError),
+    ],
+)
+def test_parse(value, rtype):
+    if issubclass(rtype, BaseException):
+        with pytest.raises(rtype):
+            skips.parse(value)
+        return
+    skf = skips.parse(value)
+    assert isinstance(skf, rtype)
+
+
+@pytest.mark.parametrize(
+    "value,ret",
+    [
+        ("file:/var/lib/foo/a", "skip-if-file-exists: /var/lib/foo/a exists"),
+        (
+            "file:!/var/lib/bar/a",
+            "skip-if-file-missing: /var/lib/bar/a missing",
+        ),
+        ("file:/etc/blat", None),
+        ("env:PLINK==0", "env var: PLINK -> 0 == 0"),
+        ("env:PLINK!=88", "env var: PLINK -> 0 != 88"),
+        ("env:PLONK==enabled", None),
+        ("always:", "always skip"),
+    ],
+)
+def test_method_test(value, ret, monkeypatch):
+    def _exists(p):
+        rv = p.startswith("/var/lib/foo/")
+        return rv
+
+    monkeypatch.setattr("os.path.exists", _exists)
+    monkeypatch.setenv("PLINK", "0")
+    monkeypatch.setenv("PLONK", "disabled")
+    skf = skips.parse(value)
+    ctx = mock.MagicMock()
+    assert skf.test(ctx) == ret
+
+
+def test_test(monkeypatch):
+    def _exists(p):
+        rv = p.startswith("/var/lib/foo/")
+        return rv
+
+    monkeypatch.setattr("os.path.exists", _exists)
+    monkeypatch.setenv("PLINK", "0")
+    monkeypatch.setenv("PLONK", "disabled")
+
+    conds = [
+        skips.SkipEnv("==", "PLINK", "1"),
+        skips.SkipEnv("!=", "PLONK", "disabled"),
+        skips.SkipAlways(),
+    ]
+    ctx = mock.MagicMock()
+    assert skips.test(ctx, conditions=conds) == "always skip"
+    conds = conds[:-1]
+    assert not skips.test(ctx, conditions=conds)
+    monkeypatch.setenv("PLINK", "1")
+    assert skips.test(ctx, conditions=conds) == "env var: PLINK -> 1 == 1"
+
+    ctx.cli.skip_conditions = conds
+    assert skips.test(ctx) == "env var: PLINK -> 1 == 1"
+
+
+def test_help_info():
+    txt = skips._help_info()
+    assert "file:" in txt
+    assert "env:" in txt
+    assert "always:" in txt
+
+
+def test_parse_hack():
+    import argparse
+
+    with pytest.raises(argparse.ArgumentTypeError):
+        skips.parse("?")


### PR DESCRIPTION
Depends on: #119

Previously, sambacc had the `--skip-if-file=` command line option that
would skip running a command if a named file exists. I have a need for
doing something similar for environment variable contents. In order to
avoid needing to add a plethora of new --skip-if-x type options over
time, add a more generic `--skip-if=` option and have the value contain
an initial prefix like `file:` or `env:` that determines how the rest of
the value will be parsed and how the skip will be determined (or not).
Deprecate `--skip-if-file`.

Maybe it's a case of over engineering, but at least it's easy to unit
test.

Examples:
* `--skip-if=env:CHAT==yes`, if the environment variable `CHAT` contains
  a value equal to "yes" the command will be skipped
* `--skip-if=file:/foo/bar` if the file `/foo/bar` exists the command
  will be skipped
* `--skip-if=file:!/foo/bar` if the file `/foo/bar` does not exist the command
  will be skipped
* `--skip-if=env:MODE!=777`, if the environment variable `MODE` contains
  a value not equal to "777" the command will be skipped
* `--skip-if=always:`, always skip this command (mainly to be used for
  testing/hacking on things)