### PR TITLE
commands: tweak --skip-if help string

### DIFF
--- a/sambacc/commands/main.py
+++ b/sambacc/commands/main.py
@@ -106,7 +106,7 @@ def global_args(parser: Parser) -> None:
         type=skips.parse,
         help=(
             "Skip execution based on a condition. Conditions include"
-            " 'file:<path>', 'env:<var>(==|!=)<value>', and 'always:'."
+            " 'file:[!]<path>', 'env:<var>(==|!=)<value>', and 'always:'."
             " (Pass `?` for more details)"
         ),
     )


### PR DESCRIPTION
Include the ability to skip if a file is missing with a `!` char (tersely) in the help string of the `--skip-if` option.