### PR TITLE
Extend support for ctdb cluster meta stored in ceph rados

### DIFF
--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -24,7 +24,8 @@ import typing
 
 from sambacc import ctdb
 from sambacc import jfile
-from sambacc.simple_waiter import Waiter
+from sambacc import rados_opener
+from sambacc.simple_waiter import Sleeper, Waiter
 
 from .cli import best_waiter, commands, Context, Fail
 
@@ -195,6 +196,12 @@ class NodeParams:
         # don't do file modes the way we need for JSON state file or do
         # writable file types in the url_opener (urllib wrapper). For now, just
         # manually handle the string.
+        if rados_opener.is_rados_uri(uri):
+            self._cluster_meta_obj = (
+                rados_opener.ClusterMetaRADOSObject.create_from_uri(uri)
+            )
+            self._waiter_obj = Sleeper()
+            return
         if uri.startswith("file:"):
             path = uri.split(":", 1)[-1]
         else:

--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -86,6 +86,17 @@ def _ctdb_general_node_args(parser: argparse.ArgumentParser) -> None:
         ),
     )
     parser.add_argument(
+        "--take-node-number-from-env",
+        "-E",
+        const="NODE_NUMBER",
+        nargs="?",
+        help=(
+            "Take the node number from the environment. If specified"
+            " with a value, use that value as the environment variable"
+            " name. Otherwise, use environment variable NODE_NUMBER."
+        ),
+    )
+    parser.add_argument(
         "--persistent-path",
         help="Path to a persistent path for storing nodes file",
     )
@@ -147,6 +158,16 @@ class NodeParams:
                     f"invalid hostname for node number: {self.hostname}"
                 )
             self.node_number = int(self.hostname.rsplit("-")[-1])
+        elif ctx.cli.take_node_number_from_env:
+            try:
+                self.node_number = int(
+                    os.environ[ctx.cli.take_node_number_from_env]
+                )
+            except (KeyError, ValueError):
+                raise ValueError(
+                    "failed to get node number from environment var"
+                    f" {ctx.cli.take_node_number_from_env}"
+                )
         else:
             self.node_number = None
 

--- a/sambacc/commands/main.py
+++ b/sambacc/commands/main.py
@@ -302,9 +302,9 @@ def pre_action(cli: typing.Any) -> None:
     if cli.samba_command_prefix:
         samba_cmds.set_global_prefix([cli.samba_command_prefix])
 
-    # should there be an option to force {en,dis}able openers?
+    # should there be an option to force {en,dis}able rados?
     # Right now we just always try to enable rados when possible.
-    rados_opener.enable_rados_url_opener(
+    rados_opener.enable_rados(
         url_opener.URLOpener,
         client_name=cli.ceph_id.get("client_name", ""),
         full_name=cli.ceph_id.get("full_name", False),

--- a/sambacc/rados_opener.py
+++ b/sambacc/rados_opener.py
@@ -388,15 +388,17 @@ def is_rados_uri(uri: str) -> bool:
     return uri.startswith("rados:")
 
 
-def enable_rados_url_opener(
+def enable_rados(
     cls: typing.Type[url_opener.URLOpener],
     *,
     client_name: str = "",
     full_name: bool = False,
 ) -> None:
-    """Extend the URLOpener type to support pseudo-URLs for rados
-    object storage. If rados libraries are not found the function
-    does nothing.
+    """Enable Ceph RADOS support in sambacc.
+    As as side-effect it will extend the URLOpener type to support pseudo-URLs
+    for rados object storage. It will also enable the
+    ClusterMetaRADOSObject.create_from_uri constructor. If rados libraries are
+    not found the function does nothing.
 
     If rados libraries are found than URLOpener can be used like:
     >>> uo = url_opener.URLOpener()

--- a/sambacc/rados_opener.py
+++ b/sambacc/rados_opener.py
@@ -25,7 +25,7 @@ import typing
 import urllib.request
 
 from . import url_opener
-from .typelets import ExcType, ExcValue, ExcTraceback
+from .typelets import ExcType, ExcValue, ExcTraceback, Self
 
 _RADOSModule = typing.Any
 _RADOSObject = typing.Any
@@ -80,16 +80,23 @@ class _RADOSHandler(urllib.request.BaseHandler):
 # it's quite annoying to have a read-only typing.IO we're forced to
 # have so many stub methods. Go's much more granular io interfaces for
 # readers/writers is much nicer for this.
-class _RADOSResponse(typing.IO):
+class RADOSObjectRef(typing.IO):
     def __init__(
-        self, interface: _RADOSInterface, pool: str, ns: str, key: str
+        self,
+        interface: _RADOSInterface,
+        pool: str,
+        ns: str,
+        key: str,
+        *,
+        must_exist: bool = True,
     ) -> None:
         self._pool = pool
         self._ns = ns
         self._key = key
 
         self._open(interface)
-        self._test()
+        if must_exist:
+            self._test()
 
     def _open(self, interface: _RADOSInterface) -> None:
         # TODO: connection caching
@@ -142,7 +149,7 @@ class _RADOSResponse(typing.IO):
     def name(self) -> str:
         return self._key
 
-    def __enter__(self) -> _RADOSResponse:
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(
@@ -150,7 +157,7 @@ class _RADOSResponse(typing.IO):
     ) -> None:
         self.close()
 
-    def __iter__(self) -> _RADOSResponse:
+    def __iter__(self) -> Self:
         return self
 
     def __next__(self) -> bytes:

--- a/sambacc/rados_opener.py
+++ b/sambacc/rados_opener.py
@@ -380,6 +380,14 @@ class ClusterMetaRADOSObject:
         return cls(handler, uri)
 
 
+def is_rados_uri(uri: str) -> bool:
+    """Return true if the string can be used as a rados (pseudo) URI.
+    This function does not require the rados libraries to be available.
+    NB: It does not validate the structure of the URI.
+    """
+    return uri.startswith("rados:")
+
+
 def enable_rados_url_opener(
     cls: typing.Type[url_opener.URLOpener],
     *,

--- a/tests/test_rados_opener.py
+++ b/tests/test_rados_opener.py
@@ -35,13 +35,13 @@ def test_enable_rados_url_opener(monkeypatch):
     monkeypatch.setitem(sys.modules, "rados", mock)
 
     cls_mock = unittest.mock.MagicMock()
-    sambacc.rados_opener.enable_rados_url_opener(cls_mock)
+    sambacc.rados_opener.enable_rados(cls_mock)
     assert cls_mock._handlers.append.called
 
 
 def test_enable_rados_url_opener_fail(monkeypatch):
     cls_mock = unittest.mock.MagicMock()
-    sambacc.rados_opener.enable_rados_url_opener(cls_mock)
+    sambacc.rados_opener.enable_rados(cls_mock)
     assert not cls_mock._handlers.append.called
 
 
@@ -51,7 +51,7 @@ def test_enable_rados_url_opener_with_args(monkeypatch):
 
     cls_mock = unittest.mock.MagicMock()
     cls_mock._handlers = []
-    sambacc.rados_opener.enable_rados_url_opener(cls_mock, client_name="user1")
+    sambacc.rados_opener.enable_rados(cls_mock, client_name="user1")
     assert len(cls_mock._handlers) == 1
     assert isinstance(
         cls_mock._handlers[0]._interface, sambacc.rados_opener._RADOSInterface
@@ -74,7 +74,7 @@ def test_enable_rados_url_opener_with_args2(monkeypatch):
 
     cls_mock = unittest.mock.MagicMock()
     cls_mock._handlers = []
-    sambacc.rados_opener.enable_rados_url_opener(
+    sambacc.rados_opener.enable_rados(
         cls_mock, client_name="client.user1", full_name=True
     )
     assert len(cls_mock._handlers) == 1

--- a/tests/test_rados_opener.py
+++ b/tests/test_rados_opener.py
@@ -133,7 +133,7 @@ def test_rados_response_read_all():
     mock = unittest.mock.MagicMock()
     mock.Rados.return_value.open_ioctx.return_value.read.side_effect = _read
 
-    rr = sambacc.rados_opener._RADOSResponse(mock, "foo", "bar", "baz")
+    rr = sambacc.rados_opener.RADOSObjectRef(mock, "foo", "bar", "baz")
     assert rr.readable()
     assert not rr.seekable()
     assert not rr.writable()
@@ -160,7 +160,7 @@ def test_rados_response_read_chunks():
     mock = unittest.mock.MagicMock()
     mock.Rados.return_value.open_ioctx.return_value.read.side_effect = _read
 
-    rr = sambacc.rados_opener._RADOSResponse(mock, "foo", "bar", "baz")
+    rr = sambacc.rados_opener.RADOSObjectRef(mock, "foo", "bar", "baz")
     assert rr.readable()
     assert rr.read(8) == b"a bad ca"
     assert rr.read(8) == b"t lives "
@@ -178,7 +178,7 @@ def test_rados_response_read_ctx_iter():
     mock = unittest.mock.MagicMock()
     mock.Rados.return_value.open_ioctx.return_value.read.side_effect = _read
 
-    rr = sambacc.rados_opener._RADOSResponse(mock, "foo", "bar", "baz")
+    rr = sambacc.rados_opener.RADOSObjectRef(mock, "foo", "bar", "baz")
     with rr:
         result = [value for value in rr]
     assert result == [sval]
@@ -189,7 +189,7 @@ def test_rados_response_read_ctx_iter():
 def test_rados_response_not_implemented():
     mock = unittest.mock.MagicMock()
 
-    rr = sambacc.rados_opener._RADOSResponse(mock, "foo", "bar", "baz")
+    rr = sambacc.rados_opener.RADOSObjectRef(mock, "foo", "bar", "baz")
     with pytest.raises(NotImplementedError):
         rr.seek(10)
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
Depends on #122

Add support to rados module to implement the ClusterMeta protocol.
Add rados support to sambacc ctdb commands.
Add a helpful CLI option for getting node number from env (it's a bit unrelated to the rados focus of the other changes but I didn't want to file a whole PR just for that).