### PR TITLE
Add some more ctdb related hacks

### DIFF
--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -62,6 +62,10 @@ def _ctdb_migrate_args(parser: argparse.ArgumentParser) -> None:
         default=ctdb.DB_DIR,
         help="Specify where CTDB database files will be written.",
     )
+    parser.add_argument(
+        "--archive",
+        help="Move converted TDB files to an archive dir.",
+    )
 
 
 def _ctdb_general_node_args(parser: argparse.ArgumentParser) -> None:
@@ -250,6 +254,8 @@ def ctdb_migrate(ctx: Context) -> None:
     """Migrate standard samba databases to CTDB databases."""
     _ctdb_ok()
     ctdb.migrate_tdb(ctx.instance_config, ctx.cli.dest_dir)
+    if ctx.cli.archive:
+        ctdb.archive_tdb(ctx.instance_config, ctx.cli.archive)
 
 
 def _lookup_hostname(hostname):

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -586,6 +586,23 @@ def _convert_tdb_file(tdb_path: str, dest_dir: str, pnn: int = 0) -> None:
     subprocess.check_call(list(cmd))
 
 
+def archive_tdb(iconfig: config.InstanceConfig, dest_dir: str) -> None:
+    """Arhive TDB files into a given directory."""
+    # TODO: these paths should be based on our instance config, not hard coded
+    try:
+        os.mkdir(dest_dir)
+        _logger.debug("dest_dir: %r created", dest_dir)
+    except FileExistsError:
+        _logger.debug("dest_dir: %r already exists", dest_dir)
+    for tdbfile in _SRC_TDB_FILES:
+        for parent in _SRC_TDB_DIRS:
+            tdb_path = os.path.join(parent, tdbfile)
+            if _has_tdb_file(tdb_path):
+                dest_path = os.path.join(dest_dir, tdbfile)
+                _logger.info("archiving: %r -> %r", tdb_path, dest_path)
+                os.rename(tdb_path, dest_path)
+
+
 def check_nodestatus(cmd: samba_cmds.SambaCommand = samba_cmds.ctdb) -> None:
     cmd_ctdb_check = cmd["nodestatus"]
     samba_cmds.execute(cmd_ctdb_check)


### PR DESCRIPTION
Add some additional options to the ctdb related sambacc commmands. The --write-node option in particular is a bit hacky but it helps me get on with prototyping samba+ctdb in containers under ceph.