### PR TITLE
ctdb: wrap reclock script

### DIFF
--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -187,6 +187,10 @@ sambatool = SambaCommand("samba-tool")
 
 smbcontrol = SambaCommand("smbcontrol")
 
+ctdb_mutex_ceph_rados_helper = SambaCommand(
+    "/usr/libexec/ctdb/ctdb_mutex_ceph_rados_helper"
+)
+
 
 def encode(value: typing.Union[str, bytes, None]) -> bytes:
     if value is None:


### PR DESCRIPTION
Depends on: #124 

Add a new `ctdb-rados-mutex` subcommand that is meant to serve as a direct wrapper around the `ctdb_mutex_ceph_rados_helper` command that "understands" some of the
intended container workflow and argument style AND prevent issues in ctdb configuration where the cephx entity names are going to vary.
