### PR TITLE
ctdb: nodes list command, wait for ctdb option

### DIFF
--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -394,9 +394,7 @@ def ctdb_must_have_node(ctx: Context) -> None:
         waiter.wait()
     if ctx.cli.write_nodes:
         _logger.info("Writing nodes file")
-        ctdb.cluster_meta_to_nodes(
-            np.cluster_meta(), real_path=np.persistent_path
-        )
+        ctdb.cluster_meta_to_nodes(np.cluster_meta(), dest=np.persistent_path)
 
 
 def _ctdb_rados_mutex_args(parser: argparse.ArgumentParser) -> None:

--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -21,6 +21,7 @@ import contextlib
 import logging
 import os
 import socket
+import sys
 import typing
 
 from sambacc import ctdb
@@ -439,6 +440,15 @@ def ctdb_rados_mutex(ctx: Context) -> None:
         cmd = cmd["-n", namespace]
     _logger.debug("executing command: %r", cmd)
     samba_cmds.execute(cmd)  # replaces process
+
+
+@commands.command(name="ctdb-list-nodes", arg_func=_ctdb_general_node_args)
+def ctdb_list_nodes(ctx: Context) -> None:
+    """Write nodes content to stdout based on current cluster meta."""
+    _ctdb_ok()
+    np = NodeParams(ctx)
+
+    ctdb.cluster_meta_to_nodes(np.cluster_meta(), sys.stdout)
 
 
 class ErrorLimiter:

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -128,6 +128,9 @@ def write_ctdb_conf(
     fh.write(enc("\n"))
     fh.write(enc("[cluster]\n"))
     _write_param("recovery lock", "recovery_lock")
+    if ctdb_params.get("nodes_cmd"):
+        nodes_cmd = ctdb_params["nodes_cmd"]
+        fh.write(enc(f"nodes list = !{nodes_cmd}"))
     fh.write(enc("\n"))
     fh.write(enc("[legacy]\n"))
     _write_param("realtime scheduling", "realtime_scheduling")

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -481,7 +481,9 @@ def _node_update(cmeta: ClusterMeta, real_path: str) -> bool:
     return True
 
 
-def cluster_meta_to_nodes(cmeta: ClusterMeta, real_path: str) -> None:
+def cluster_meta_to_nodes(
+    cmeta: ClusterMeta, dest: typing.Union[str, typing.IO]
+) -> None:
     """Write a nodes file based on the current content of the cluster
     metadata."""
     with cmeta.open(locked=True) as cmo:
@@ -489,8 +491,11 @@ def cluster_meta_to_nodes(cmeta: ClusterMeta, real_path: str) -> None:
         nodes = json_data.get("nodes", [])
         _logger.info("Found node metadata: %r", nodes)
         ctdb_nodes = _cluster_meta_to_ctdb_nodes(nodes)
-        _logger.info("Will write nodes: %s", ctdb_nodes)
-        _save_nodes(real_path, ctdb_nodes)
+        if isinstance(dest, str):
+            _logger.info("Will write nodes: %s", ctdb_nodes)
+            _save_nodes(dest, ctdb_nodes)
+        else:
+            write_nodes_file(dest, ctdb_nodes)
 
 
 def _cluster_meta_to_ctdb_nodes(nodes: list[dict]) -> list[str]:


### PR DESCRIPTION
Add a `samba-container ctdb-list-nodes` command that emits a "nodes file" content to the stdout of the process.
Add hooks to set up a ctdb "nodes_cmd" config file option that tells ctdb to execute a command to fetch the nodes rather than read a file.

Also add a `--wait-for=ctdb` option to avoid starting certain services before ctdb is available and causing unnecessary container restarts.