### PR TITLE
github: Update mergify config to replace deprecated attributes

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,4 @@
 ---
-defaults:
-  actions:
-    queue:
-      name: default
-      method: rebase
-      update_method: rebase
-
-
 # each test should be listed separately, do not use regular expressions:
 # https://docs.mergify.io/conditions.html#validating-all-status-check
 # TODO: Use mergify's recently added 'shared configuration support'
@@ -19,6 +11,8 @@ queue_rules:
       - check-success=test (fedora-40)
       - check-success=test (centos-stream9)
       - check-success=dpulls
+    merge_method: rebase
+    update_method: rebase
 
 
 pull_request_rules:


### PR DESCRIPTION
> ❗❗ Action Required ❗❗
> 
> **The configuration uses the deprecated `merge_method` attribute of the queue action in one or more `pull_request_rules`. It must now be used under the `queue_rules` configuration.**
> A brownout is planned on August 26th, 2024.
> This option will be removed on September 23rd, 2024. For more information: https://docs.mergify.com/configuration/file-format/#queue-rules
> 
> ❗❗ Action Required ❗❗
> 
> **The configuration uses the deprecated `update_method` attribute of the queue action in one or more `pull_request_rules`. It must now be used under the `queue_rules` configuration.**
> A brownout is planned on August 26th, 2024.
> This option will be removed on September 23rd, 2024. For more information: https://docs.mergify.com/configuration/file-format/#queue-rules
> 

ref: https://docs.mergify.com/workflow/actions/queue/#parameters