### PR TITLE
Add simple support for ctdb public addrs

### DIFF
--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -70,7 +70,7 @@ def _ctdb_nodes_exists(ctx: Context) -> None:
 def _ctdb_etc_files(ctx: Context) -> None:
     if ctx.instance_config.with_ctdb and ctx.expects_ctdb:
         _logger.info("Ensuring ctdb etc files")
-        ctdb.ensure_ctdbd_etc_files()
+        ctdb.ensure_ctdbd_etc_files(iconfig=ctx.instance_config)
 
 
 @setup_steps.command("share_paths")

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -315,6 +315,8 @@ class InstanceConfig:
         ctdb.setdefault("log_level", "DEBUG")
         ctdb.setdefault("script_log_level", "DEBUG")
         ctdb.setdefault("realtime_scheduling", "false")
+        # this whole thing really needs to be turned into a real object type
+        ctdb.setdefault("public_addresses", [])
         return ctdb
 
     def domain(self) -> DomainConfig:


### PR DESCRIPTION
Allow sambacc to set up the public_addresses file for ctdb and enable the required event script for basic ip failover.