### PR TITLE
sambacc: fix constructing interface list for ctdb public_addresses

### DIFF
--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -197,9 +197,9 @@ def _write_public_addresses_file(
     fh: typing.IO, addrs: list[PublicAddrAssignment]
 ) -> None:
     for entry in addrs:
-        fh.write(f"{entry['address']}")
+        fh.write(entry["address"])
         if entry["interfaces"]:
-            ifaces = " ".join(entry["interfaces"])
+            ifaces = ",".join(entry["interfaces"])
             fh.write(f" {ifaces}")
         fh.write("\n")
 


### PR DESCRIPTION
The samba wiki and documentation clearly state that the list of interfaces should be comma separated but I incorrectly joined them with spaces. Fix this and one other small suboptimal line in the same function.