### PR TITLE
ctdb: Leave CTDB log levels at their original defaults

### DIFF
--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -312,8 +312,8 @@ class InstanceConfig:
         ctdb.setdefault("cluster_meta_uri", CLUSTER_META_JSON)
         ctdb.setdefault("nodes_path", CTDB_NODES_PATH)
         ctdb.setdefault("recovery_lock", CTDB_RECLOCK)
-        ctdb.setdefault("log_level", "DEBUG")
-        ctdb.setdefault("script_log_level", "DEBUG")
+        ctdb.setdefault("log_level", "NOTICE")
+        ctdb.setdefault("script_log_level", "ERROR")
         ctdb.setdefault("realtime_scheduling", "false")
         # this whole thing really needs to be turned into a real object type
         ctdb.setdefault("public_addresses", [])

--- a/tests/test_ctdb.py
+++ b/tests/test_ctdb.py
@@ -438,7 +438,8 @@ def test_ensure_ctdb_conf(tmpdir):
     ctdb.ensure_ctdb_conf(iconfig=cfg.get("ctdb1"), path=path)
     with open(path, "r") as fh:
         data = fh.read()
-    assert "DEBUG" in data
+    assert "NOTICE" in data
+    assert "ERROR" in data
     assert "/var/lib/ctdb/shared/RECOVERY" in data
 
 


### PR DESCRIPTION
There is too much information with the `log level` explicitily set to DEBUG for _ctdbd_ flooding the log file destination. Similarly `script log level` option might also spit out more when set to DEBUG. Instead of removing the options altogether we change the sambacc defaults from DEBUG to NOTCE and ERROR respectively for `log level` and `script log level` options as specified in man [ctdb.conf(5)](https://ctdb.samba.org/manpages/ctdb.conf.5.html).