### PR TITLE
workflows: update test matrix to use fedora 41

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -7,7 +7,7 @@ queue_rules:
   - name: default
     conditions:
       - check-success=check-commits
-      - check-success=test (fedora-39)
+      - check-success=test (fedora-41)
       - check-success=test (fedora-40)
       - check-success=test (centos-stream9)
       - check-success=dpulls
@@ -28,7 +28,7 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - check-success=check-commits
-      - check-success=test (fedora-39)
+      - check-success=test (fedora-41)
       - check-success=test (fedora-40)
       - check-success=test (centos-stream9)
       - check-success=dpulls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_distro: ["fedora-40", "fedora-39", "centos-stream9"]
+        test_distro: ["fedora-40", "fedora-41", "centos-stream9"]
         include:
           - test_distro: "fedora-40"
             base_image: "registry.fedoraproject.org/fedora:40"
-          - test_distro: "fedora-39"
-            base_image: "registry.fedoraproject.org/fedora:39"
+          - test_distro: "fedora-41"
+            base_image: "registry.fedoraproject.org/fedora:41"
           - test_distro: "centos-stream9"
             base_image: "quay.io/centos/centos:stream9"
     steps:


### PR DESCRIPTION
Fedora 41 has been out for some weeks now. Update the test matrix to remove Fedora 39 and use fedora 41.