### PR TITLE
tests/container: update base image to fedora 41

### DIFF
--- a/tests/container/Containerfile
+++ b/tests/container/Containerfile
@@ -1,4 +1,4 @@
-ARG SAMBACC_BASE_IMAGE='registry.fedoraproject.org/fedora:39'
+ARG SAMBACC_BASE_IMAGE='registry.fedoraproject.org/fedora:41'
 FROM $SAMBACC_BASE_IMAGE
 
 


### PR DESCRIPTION
Forgot to update this when we updated the workflows file.