### PR TITLE
commands: fix a mypy failure in the ctdb commands module

### DIFF
--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -271,17 +271,19 @@ def _lookup_hostname(hostname: str) -> str:
         )
         ipv6_address = None
 
-        for entry in addrinfo:
-            family, _, _, _, sockaddr = entry
-            ip_address = sockaddr[0]
-
-            if ip_address.startswith("127.") or ip_address == "::1":
-                continue
-
+        for family, _, _, _, sockaddr in addrinfo:
             if family == socket.AF_INET:
+                ip_address = sockaddr[0]
+                assert isinstance(ip_address, str)
+                if ip_address.startswith("127."):
+                    continue
                 return ip_address
 
             if family == socket.AF_INET6 and ipv6_address is None:
+                ip_address = sockaddr[0]
+                assert isinstance(ip_address, str)
+                if ip_address == "::1":
+                    continue
                 ipv6_address = ip_address
 
         if ipv6_address:


### PR DESCRIPTION
It seems that a recent mypy release is now determining that certain family types (not AF_INET, or AF_INET6) may return an address tupe with the first element type being an int rather than a str. The (expanded) revealed type is:
```
tuple[
    socket.AddressFamily,
    socket.SocketKind,
    builtins.int,
    builtins.str,
    Union[
        tuple[builtins.str, builtins.int],
        tuple[builtins.str, builtins.int, builtins.int, builtins.int],
        tuple[builtins.int, builtins.bytes]
    ]
]
```

This change ensures that we only check the family values we care about and use a type assertion for those families where we expect the address value to be a str.

FWIW I could not find any documentation for what families have an integer in the first element of the addr tuple. Looking at the python sources it seems like it could be AF_NETLINK, AF_QIPCRTR, AF_VSOCK - all families I have never seen in the wild before :-)