### PR TITLE
commands: Simplify _lookup_hostname() in ctdb module

### DIFF
--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -269,25 +269,14 @@ def _lookup_hostname(hostname: str) -> str:
             family=socket.AF_UNSPEC,
             type=socket.SOCK_STREAM,
         )
-        ipv6_address = None
 
         for family, _, _, _, sockaddr in addrinfo:
-            if family == socket.AF_INET:
+            if family == socket.AF_INET or family == socket.AF_INET6:
                 ip_address = sockaddr[0]
                 assert isinstance(ip_address, str)
-                if ip_address.startswith("127."):
+                if ip_address.startswith("127.") or ip_address == "::1":
                     continue
                 return ip_address
-
-            if family == socket.AF_INET6 and ipv6_address is None:
-                ip_address = sockaddr[0]
-                assert isinstance(ip_address, str)
-                if ip_address == "::1":
-                    continue
-                ipv6_address = ip_address
-
-        if ipv6_address:
-            return ipv6_address
 
         raise RuntimeError(
             f"No valid IP address found for hostname '{hostname}'."


### PR DESCRIPTION
              @avanthakkar Why are we not returning IPv6 address from here? What special case are we dealing with additional `ipv6_address`?

_Originally posted by @anoopcs9 in https://github.com/samba-in-kubernetes/sambacc/pull/146#discussion_r1953874786_
            