### PR TITLE
commands: handle /usr/etc/nsswitch.conf

### DIFF
--- a/sambacc/textfile.py
+++ b/sambacc/textfile.py
@@ -28,11 +28,14 @@ class TextFileLoader:
         with open(self.path) as f:
             self.readfp(f)
 
-    def write(self) -> None:
-        tpath = self._tmp_path(self.path)
+    def write(self, alternate_path: typing.Optional[str] = None) -> None:
+        path = self.path
+        if alternate_path:
+            path = alternate_path
+        tpath = self._tmp_path(path)
         with open(tpath, "w") as f:
             self.writefp(f)
-        os.rename(tpath, self.path)
+        os.rename(tpath, path)
 
     def _tmp_path(self, path: str) -> str:
         # for later: make this smarter


### PR DESCRIPTION
On some newer OS releases, standard config files are installed in /usr/etc with site changes to copies in /etc.

That results in the following startup failure:
Traceback (most recent call last):
  File "/usr/bin/samba-container", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "sambacc/commands/main.py", line 231, in main
    cfunc(CommandContext(cli))
  File "sambacc/commands/run.py", line 75, in run_container
    init_container(ctx)
  File "sambacc/commands/initialize.py", line 116, in init_container
    cmds[step_name].cmd_func(ctx)
  File "sambacc/commands/initialize.py", line 38, in _import_nsswitch
    nss.read()
  File "sambacc/textfile.py", line 28, in read
    with open(self.path) as f:
         ^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/etc/nsswitch.conf'

This changes the initialization so that we fall back to reading from /usr/etc/nsswitch.conf if reading from /etc/nsswitch.conf fails but still write out any changes to /etc/nsswitch.conf.