### PR TITLE
ctdb: skip mutex helper service registration

### DIFF
--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -469,6 +469,10 @@ def ctdb_rados_mutex(ctx: Context) -> None:
     # optional namespace argument
     if namespace:
         cmd = cmd["-n", namespace]
+    skip_reg_option = samba_cmds.ctdb_rados_mutex_skip_registration_opt()
+    if skip_reg_option:
+        # skip registring ctdb rados mutex helper as a service
+        cmd = cmd[skip_reg_option]
     _logger.debug("executing command: %r", cmd)
     samba_cmds.execute(cmd)  # replaces process
 

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -31,6 +31,7 @@ _GLOBAL_DEBUG: str = ""
 # Known flags for SAMBA_SPECIFICS env variable
 _DAEMON_CLI_STDOUT_OPT: str = "daemon_cli_debug_output"
 _CTDB_LEADER_ADMIN_CMD: str = "ctdb_leader_admin_command"
+_CTDB_RADOS_MUTEX_SKIP_REG: str = "ctdb_rados_mutex_skip_reg"
 
 
 def get_samba_specifics() -> typing.Set[str]:
@@ -59,6 +60,12 @@ def ctdb_leader_admin_cmd() -> str:
     if _CTDB_LEADER_ADMIN_CMD in opt_lst:
         leader_cmd = "leader"
     return leader_cmd
+
+
+def ctdb_rados_mutex_skip_registration_opt() -> str:
+    if _CTDB_RADOS_MUTEX_SKIP_REG in get_samba_specifics():
+        return "-R"  # skip registration option
+    return ""
 
 
 def set_global_prefix(lst: list[str]) -> None:


### PR DESCRIPTION
Depends on: https://gitlab.com/samba-team/samba/-/merge_requests/4002



When the ctdb ceph rados mutex helper tool supports the -R option to
skip registering the helper as a ceph service - do so.
This avoids confusion on the ceph side as the helper will act more like
a typical rados client than something on the level of an OSD or MDS.