### PR TITLE
rpm: vendor dist suffix

### DIFF
--- a/extras/python-sambacc.spec
+++ b/extras/python-sambacc.spec
@@ -9,7 +9,7 @@
 
 Name:           python-%{bname}
 Version:        %{rversion}
-Release:        1%{?dist}
+Release:        1%{?dist}%{?vendordist}
 Summary:        Samba Container Configurator
 
 License:        GPLv3+

--- a/tests/container/build.sh
+++ b/tests/container/build.sh
@@ -198,11 +198,15 @@ task_rpm_build() {
             tar -xf "$spkg" -O \
                 "sambacc-${ver}/extras/python-sambacc.spec"
         ) > "${tdir}/python-sambacc.spec"
-        rpmbuild "${rpmbuild_stage}" \
+        rpmbuild_cmd=(rpmbuild "${rpmbuild_stage}" \
             -D "_rpmdir ${distdir}/RPMS" \
             -D "_srcrpmdir ${distdir}/SRPMS" \
             -D "_sourcedir $(dirname "${spkg}")" \
-            "${tdir}/python-sambacc.spec"
+        )
+        if [ "$VENDOR_DIST_SUFFIX" ]; then
+            rpmbuild_cmd+=(-D "vendordist ${VENDOR_DIST_SUFFIX}")
+        fi
+        "${rpmbuild_cmd[@]}" "${tdir}/python-sambacc.spec"
         rm -rf "${tdir}"
     done
 }


### PR DESCRIPTION
Allow a vendor dist suffix field in the spec file.

It can be passed to the build script with the VENDOR_DIST_SUFFIX env var
set to a value. Then it will pass that along to the rpm build as the
vendordist value to be suffixed to the release ver.