### PR TITLE
samba_cmds: Do not add --debuglevel for `wbinfo` and `ctdb` commands

### DIFF
--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -764,12 +764,12 @@ def archive_tdb(iconfig: config.InstanceConfig, dest_dir: str) -> None:
                 os.rename(tdb_path, dest_path)
 
 
-def check_nodestatus(cmd: samba_cmds.SambaCommand = samba_cmds.ctdb) -> None:
+def check_nodestatus(cmd: samba_cmds.CommandArgs = samba_cmds.ctdb) -> None:
     cmd_ctdb_check = cmd["nodestatus"]
     samba_cmds.execute(cmd_ctdb_check)
 
 
-def _read_command_pnn(cmd: samba_cmds.SambaCommand) -> typing.Optional[int]:
+def _read_command_pnn(cmd: samba_cmds.CommandArgs) -> typing.Optional[int]:
     """Run a ctdb command assuming it returns a pnn value. Return the pnn as an
     int on success, None on command failure.
     """

--- a/sambacc/samba_cmds.py
+++ b/sambacc/samba_cmds.py
@@ -188,7 +188,7 @@ ctdbd_foreground = ctdbd["--interactive"]
 
 ltdbtool = CommandArgs("ltdbtool")
 
-ctdb = SambaCommand("ctdb")
+ctdb = CommandArgs("ctdb")
 
 sambatool = SambaCommand("samba-tool")
 


### PR DESCRIPTION
**wbinfo** and **ctdb** commands do not accept `--debuglevel` optional argument. Make sure that we execute those commands without `--debuglevel` in the presence of `--samba-debug-level` optional argument to **samba-container** command or its equivalent with `SAMBA_DEBUG_LEVEL` environment variable.

fixes https://github.com/samba-in-kubernetes/sambacc/issues/141