### PR TITLE
add files to include in smb.conf stub for ctdb 

### DIFF
--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -303,7 +303,7 @@ class InstanceConfig:
             raise ValueError("ctdb not supported in configuration")
         return CTDBSambaConfig()
 
-    def ctdb_config(self) -> dict[str, str]:
+    def ctdb_config(self) -> JSONData:
         """Common configuration of CTDB itself."""
         if not self.with_ctdb:
             return {}

--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -133,6 +133,7 @@ def write_ctdb_conf(
     if ctdb_params.get("nodes_cmd"):
         nodes_cmd = ctdb_params["nodes_cmd"]
         fh.write(enc(f"nodes list = !{nodes_cmd}"))
+        fh.write(enc("\n"))
     fh.write(enc("\n"))
     fh.write(enc("[legacy]\n"))
     _write_param("realtime scheduling", "realtime_scheduling")


### PR DESCRIPTION
When using ctdb most of the configuration should be managed via the
registry config via ctdb. However, there are some parameters you may
need to be per-instance. As a quick and simple way of getting custom
per host settings with ctdb allow for including additional files from
the generated stub smb.conf file.

Plus two minor cleanups noticed while hacking on this feature.