### PR TITLE
tox.ini: add a rule to reformat source code

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,12 @@ deps =
 commands =
     black --check -v --extend-exclude sambacc/grpc/generated .
 
+[testenv:reformat]
+description = Reformat the source files using black
+deps = {[testenv:formatting]deps}
+commands =
+    black -q --extend-exclude sambacc/grpc/generated .
+
 [testenv:flake8]
 description = Basic python linting for the source files
 deps =


### PR DESCRIPTION
Add a tox environment that runs black to format the code rather than just checking it. This environment is not run automatically but it provided for developers as a means to format the code in a way that is consistent with this project's configuration.