### PR TITLE
grpc: avoid a mypy warning

### DIFF
--- a/sambacc/grpc/backend.py
+++ b/sambacc/grpc/backend.py
@@ -134,7 +134,7 @@ class ControlBackend:
 
     def _sambacc_version(self) -> str:
         try:
-            import sambacc._version
+            import sambacc._version  # type: ignore
 
             return sambacc._version.version
         except ImportError:


### PR DESCRIPTION
Suddenly, completely out of the blue as far as I'm concerned, mypy started alerting on this import. Silence the silliness.

Fixes: #168 