### PR TITLE
setup.cfg: Align with version inference logic from setuptools_scm

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,6 @@
 
 [metadata]
 name = sambacc
-version = 0.1
 description = Samba Container Configurator
 author = John Mulligan
 author_email = phlogistonjohn@asynchrono.us


### PR DESCRIPTION
setuptools_scm [v9.2.0](https://github.com/pypa/setuptools-scm/releases/tag/v9.2.0) introduced some breaking changes w.r.t the logic used to detect project version. This is an attempt to cope with it in such a way that an earlier _mypy_ [warning](https://github.com/samba-in-kubernetes/sambacc/issues/168) can be fixed properly.