### PR TITLE
build.sh: Cleanup build requirements

### DIFF
--- a/tests/container/build.sh
+++ b/tests/container/build.sh
@@ -121,10 +121,8 @@ task_sys_deps() {
         python3-wheel \
         python3-pyxattr \
         python3-devel \
-        python3.9 \
         samba-common-tools \
         rpm-build \
-        'python3dist(flake8)' \
         'python3dist(inotify-simple)' \
         'python3dist(mypy)' \
         'python3dist(pytest)' \


### PR DESCRIPTION
Python 3.9 is already an old version which is still available on prominent distros and thus an explicit installation need not be a hard requirement. Also, `python3dist(flake8)` is not seen as a system dependency during the build process other than the tox environment for detecting linting errors.