### PR TITLE
sambacc: use tempfile as arg to net conf import

### DIFF
--- a/sambacc/netcmd_loader.py
+++ b/sambacc/netcmd_loader.py
@@ -18,6 +18,7 @@
 
 import subprocess
 import typing
+import tempfile
 
 from sambacc import config
 from sambacc import samba_cmds
@@ -56,10 +57,11 @@ class NetCmdLoader:
 
     def import_config(self, iconfig: config.InstanceConfig) -> None:
         """Import to entire instance config to samba config."""
-        cli, proc = self._cmd("import", "/dev/stdin", stdin=subprocess.PIPE)
-        template_config(proc.stdin, iconfig, enc=samba_cmds.encode)
-        proc.stdin.close()
-        self._check(cli, proc)
+        with tempfile.NamedTemporaryFile() as tf:
+            template_config(tf, iconfig, enc=samba_cmds.encode)
+            tf.flush()
+            cli, proc = self._cmd("import", tf.name)
+            self._check(cli, proc)
 
     def dump(self, out: typing.IO) -> None:
         """Dump the current smb config in an smb.conf format.


### PR DESCRIPTION
net conf import is unable to use the STDIN to import the configuration when the generated smb.conf is large. Use a tempfile instead as an argument to net conf import.

Resolves: rhbz#2400102