### PR TITLE
commands: work around a new flake8 failure

### DIFF
--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -25,9 +25,9 @@ import typing
 
 from sambacc import config
 from sambacc import leader
-from sambacc import opener
 from sambacc import permissions
 from sambacc import simple_waiter
+from sambacc.opener import Opener
 
 _INOTIFY_OK = True
 try:
@@ -224,7 +224,7 @@ class Context(typing.Protocol):
         """Return true if configuration needs validation."""
 
     @property
-    def opener(self) -> opener.Opener:
+    def opener(self) -> Opener:
         """Return an appropriate opener object for this instance."""
 
 


### PR DESCRIPTION
Suddenly, on the new f43 image ci run flake8 fails. Looking at the error and the code I think this failure is incorrect but I don't want to block the CI and wait for flake8 to be changed. The workaround is low cost and not much harder to understand than the original code.