### PR TITLE
ceph: create a new ceph dir and move rados_opener to ceph.rados

### DIFF
--- a/sambacc/ceph/__init__.py
+++ b/sambacc/ceph/__init__.py
@@ -1,0 +1,22 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2023  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+from . import rados
+
+enable_rados_opener = rados.enable_rados
+__all__ = ["enable_rados_opener"]

--- a/sambacc/ceph/rados.py
+++ b/sambacc/ceph/rados.py
@@ -26,8 +26,8 @@ import typing
 import urllib.request
 import uuid
 
-from . import url_opener
-from .typelets import ExcType, ExcValue, ExcTraceback, Self
+from .. import url_opener
+from ..typelets import ExcType, ExcValue, ExcTraceback, Self
 
 _RADOSModule = typing.Any
 _RADOSObject = typing.Any

--- a/sambacc/commands/common.py
+++ b/sambacc/commands/common.py
@@ -27,7 +27,7 @@ import typing
 
 from sambacc import config
 from sambacc import opener
-from sambacc import rados_opener
+from sambacc import ceph
 from sambacc import samba_cmds
 from sambacc import url_opener
 from sambacc.typelets import Self
@@ -180,7 +180,7 @@ def pre_action(cli: argparse.Namespace) -> None:
 
     # should there be an option to force {en,dis}able rados?
     # Right now we just always try to enable rados when possible.
-    rados_opener.enable_rados(
+    ceph.enable_rados_opener(
         url_opener.URLOpener,
         client_name=cli.ceph_id.get("client_name", ""),
         full_name=cli.ceph_id.get("full_name", False),

--- a/sambacc/commands/ctdb.py
+++ b/sambacc/commands/ctdb.py
@@ -26,8 +26,8 @@ import typing
 
 from sambacc import ctdb
 from sambacc import jfile
-from sambacc import rados_opener
 from sambacc import samba_cmds
+from sambacc.ceph import rados
 from sambacc.simple_waiter import Sleeper, Waiter
 
 from .cli import best_leader_locator, best_waiter, commands, Context, Fail
@@ -224,9 +224,9 @@ class NodeParams:
         # don't do file modes the way we need for JSON state file or do
         # writable file types in the url_opener (urllib wrapper). For now, just
         # manually handle the string.
-        if rados_opener.is_rados_uri(uri):
+        if rados.is_rados_uri(uri):
             self._cluster_meta_obj = (
-                rados_opener.ClusterMetaRADOSObject.create_from_uri(uri)
+                rados.ClusterMetaRADOSObject.create_from_uri(uri)
             )
             self._waiter_obj = Sleeper()
             return
@@ -449,9 +449,9 @@ def ctdb_rados_mutex(ctx: Context) -> None:
     N.B. Another reason for this command is that ctdb requires the
     `cluster lock` value to be the same on all nodes.
     """
-    if not rados_opener.is_rados_uri(ctx.cli.mutex_uri):
+    if not rados.is_rados_uri(ctx.cli.mutex_uri):
         raise ValueError(f"{ctx.cli.mutex_uri} is not a valid RADOS URI value")
-    rinfo = rados_opener.parse_rados_uri(ctx.cli.mutex_uri)
+    rinfo = rados.parse_rados_uri(ctx.cli.mutex_uri)
     if rinfo["subtype"] != "object":
         raise ValueError(
             f"{ctx.cli.mutex_uri} is not a RADOS object URI value"


### PR DESCRIPTION
Create a new namespace for ceph integrations in sambacc. Move the existing rados_opener to ceph.rados, as the module is doing far more than just supporting an opener anyway. This is in preparation for doing even more integration with ceph and rados for various parts of sambacc.