### PR TITLE
setup.cfg: Include the new 'ceph' package during build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ long_description_content_type = text/markdown
 [options]
 packages =
     sambacc
+    sambacc.ceph
     sambacc.commands
     sambacc.commands.remotecontrol
     sambacc.commands.satellite


### PR DESCRIPTION
This is required to avoid the following runtime backtrace:
```
Traceback (most recent call last):
  File "/usr/bin/samba-container", line 5, in <module>
    from sambacc.commands.main import main
  File "/usr/lib/python3.9/site-packages/sambacc/commands/main.py", line 25, in <module>
    from .common import (
  File "/usr/lib/python3.9/site-packages/sambacc/commands/common.py", line 30, in <module>
    from sambacc import ceph
ImportError: cannot import name 'ceph' from 'sambacc' (/usr/lib/python3.9/site-packages/sambacc/__init__.py)
```

fixes https://github.com/samba-in-kubernetes/samba-container/issues/239