### PR TITLE
Use `podman` and fix mypy errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build test container
-        run: docker build -t sambacc:ci-${{ matrix.test_distro }} --build-arg=SAMBACC_BASE_IMAGE=${{ matrix.base_image }}  tests/container/ -f tests/container/Containerfile
+        run: podman build -t sambacc:ci-${{ matrix.test_distro }} --build-arg=SAMBACC_BASE_IMAGE=${{ matrix.base_image }}  tests/container/ -f tests/container/Containerfile
       - name: Run test container
-        run: docker run -v $PWD:/var/tmp/build/sambacc sambacc:ci-${{ matrix.test_distro }}
+        run: podman run -v $PWD:/var/tmp/build/sambacc sambacc:ci-${{ matrix.test_distro }}
 
   push:
     needs: [test]
@@ -73,8 +73,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: log in to quay.io
-        run: docker login -u "${{ secrets.QUAY_USER }}" -p "${{ secrets.QUAY_PASS }}" quay.io
+        run: podman login -u "${{ secrets.QUAY_USER }}" -p "${{ secrets.QUAY_PASS }}" quay.io
       - name: build container image
-        run: docker build -t quay.io/samba.org/sambacc:latest tests/container -f tests/container/Containerfile
+        run: podman build -t quay.io/samba.org/sambacc:latest tests/container -f tests/container/Containerfile
       - name: publish container image
-        run: docker push quay.io/samba.org/sambacc:latest
+        run: podman push quay.io/samba.org/sambacc:latest

--- a/sambacc/grpc/backend.py
+++ b/sambacc/grpc/backend.py
@@ -526,6 +526,7 @@ class ControlBackend:
 
     def set_debug_level(self, server: ServerType, debug_level: str) -> None:
         base_cmd = debug_level_command(server)
+        cmd: sambacc.samba_cmds.CommandArgs
         if base_cmd is sambacc.samba_cmds.smbcontrol:
             cmd = base_cmd[server.value, "debug", debug_level]
         elif base_cmd is sambacc.samba_cmds.ctdb:
@@ -537,6 +538,7 @@ class ControlBackend:
     def get_debug_level(self, server: ServerType) -> str:
         _parser = None
         base_cmd = debug_level_command(server)
+        cmd: sambacc.samba_cmds.CommandArgs
         if base_cmd is sambacc.samba_cmds.smbcontrol:
             cmd = base_cmd[server.value, "debuglevel"]
             _parser = _parse_debuglevel


### PR DESCRIPTION
- Switch CI to use `podman` instead of `docker`.
- Fix mypy type errors.

Our CI has been failing for the last two weeks, and my attempt to fix the weird permission errors finally led to switching the CI to use `podman`, which magically resolved everything except the newly found mypy errors.