### PR TITLE
sambacc/ceph: Fix a new mypy var-annotated error

### DIFF
--- a/sambacc/ceph/rados.py
+++ b/sambacc/ceph/rados.py
@@ -456,7 +456,7 @@ def enable_rados_opener(
     cls._handlers.append(_RADOSHandler)
 
 
-_module = {}
+_module: dict[str, typing.Any] = {}
 
 
 def enable_rados_lib(*, ignore_error: bool = False) -> bool:


### PR DESCRIPTION
With v2.0.0, _mypy_ seems to do a strict enforcement of 'var-annotated' check when a variable type is unclear.

fixes #195 