### PR TITLE
remote-control: clarify and fix issues with access control in the grpc server

### DIFF
--- a/sambacc/commands/remotecontrol/server.py
+++ b/sambacc/commands/remotecontrol/server.py
@@ -30,8 +30,9 @@ import sambacc.grpc.config
 
 
 _logger = logging.getLogger(__name__)
-_MTLS = "mtls"
-_FORCE = "force"
+_AUTO = "auto"  # allow modifications based on conn settings
+_MTLS = "mtls"  # allow modifications based on conn tls settings
+_FORCE = "force"  # allow all modifications
 
 
 def _serve_args(parser: argparse.ArgumentParser) -> None:
@@ -67,8 +68,8 @@ def _serve_args(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument(
         "--allow-modify",
-        choices=(_MTLS, _FORCE),
-        default=_MTLS,
+        choices=(_AUTO, _MTLS, _FORCE),
+        default=_AUTO,
         help="Control modification mode",
     )
     parser.add_argument(
@@ -211,14 +212,34 @@ def _configure(ctx: Context) -> sambacc.grpc.config.ServerConfig:
         conn_config.server_cert = _read(ctx, ctx.cli.tls_cert)
     if ctx.cli.tls_ca_cert:
         conn_config.ca_cert = _read(ctx, ctx.cli.tls_ca_cert)
-    config.read_only = not (
-        ctx.cli.allow_modify == _FORCE
-        or (not conn_config.insecure and conn_config.ca_cert)
-    )
     _setup_checker(ctx, conn_config, ctx.cli.listener_opts or {})
     for extra in ctx.cli.extra_listeners or []:
         config.connections.append(_listener_conn(ctx, extra))
+    config.read_only = not _can_modify(ctx, config)
     return config
+
+
+def _can_modify(
+    ctx: Context, config: sambacc.grpc.config.ServerConfig
+) -> bool:
+    """Return true if this server should be allowed to make system
+    configuration/state modifications.
+    """
+    if ctx.cli.allow_modify == _FORCE:
+        return True
+    if ctx.cli.allow_modify == _MTLS:
+        # pre-unix or i-dont-trust-ceph-checker mode
+        return all(
+            cc.insecure or (cc.uses_tls and cc.ca_cert)
+            for cc in config.connections
+        )
+    _rados = sambacc.grpc.config.ClientVerification.RADOS
+    return all(
+        cc.insecure
+        or (cc.uses_tls and cc.ca_cert)
+        or (cc.uses_unix and cc.verification is _rados)
+        for cc in config.connections
+    )
 
 
 def _serve(ctx: Context) -> None:

--- a/sambacc/grpc/config.py
+++ b/sambacc/grpc/config.py
@@ -62,13 +62,17 @@ class ConnectionConfig:
 
     def describe(self) -> str:
         _kind = "tcp socket"
-        if self.address.startswith("unix:"):
+        if self.uses_unix:
             _kind = "unix socket"
         return f"{_kind}/{self.verification.value}"
 
     @property
     def uses_tls(self) -> bool:
         return self.verification is ClientVerification.TLS
+
+    @property
+    def uses_unix(self) -> bool:
+        return self.address.startswith("unix:")
 
     # compat properties
     @property

--- a/sambacc/grpc/rados_checker.py
+++ b/sambacc/grpc/rados_checker.py
@@ -85,3 +85,9 @@ class RADOSClientChecker:
             _logger.debug("rados check failed: %r", err)
             return False
         return True
+
+    def __str__(self) -> str:
+        return (
+            "rados-checker"
+            f"<{self._config.header_user}, {self._config.header_key}>"
+        )

--- a/sambacc/grpc/server.py
+++ b/sambacc/grpc/server.py
@@ -211,6 +211,10 @@ class LevelClientChecker:
         )
         return ok
 
+    def __str__(self) -> str:
+        levels = ", ".join(al.name for al in self._levels)
+        return f"level-checker<allow {levels}>"
+
 
 class TLSClientChecker:
     def allowed_client(
@@ -222,6 +226,9 @@ class TLSClientChecker:
             _logger.debug("Client is using (m)TLS")
             return True
         return False
+
+    def __str__(self) -> str:
+        return "tls-checker"
 
 
 class MagicTokenClientChecker:
@@ -256,6 +263,9 @@ class MagicTokenClientChecker:
             return True
         return False
 
+    def __str__(self) -> str:
+        return f"magic-token-checker<{self._key}>"
+
 
 def _rados_checker(config: RADOSCheckerConfig) -> ClientChecker:
     import sambacc.grpc.rados_checker
@@ -268,13 +278,13 @@ class ControlService(control_rpc.SambaControlServicer):
         self,
         backend: Backend,
         *,
-        read_only: bool = False,
+        access_levels: Optional[Collection[Level]] = None,
         client_checkers: Optional[Collection[ClientChecker]] = None,
     ):
         self._backend = backend
-        self._allowed_levels = {Level.READ, Level.DEBUG_READ}
-        if not read_only:
-            self._allowed_levels.add(Level.MODIFY)
+        if not access_levels:
+            access_levels = {Level.READ, Level.DEBUG_READ}
+        self._allowed_levels = access_levels
         if client_checkers:
             self._client_checkers = list(client_checkers)
         else:
@@ -555,17 +565,27 @@ def _checkers(config: ServerConfig) -> Iterator[ClientChecker]:
     yield LevelClientChecker(Level.READ)
 
 
+def _access(config: ServerConfig) -> set[Level]:
+    levels = {Level.READ, Level.DEBUG_READ, Level.MODIFY}
+    if config.read_only:
+        levels.discard(Level.MODIFY)
+    return levels
+
+
 def serve(config: ServerConfig, backend: Backend) -> None:
     if not config.connections:
         raise ValueError("no connections in server config")
+    access_levels = _access(config)
+    client_checkers = list(_checkers(config))
     _logger.info(
-        "Starting gRPC server (%s mode)",
-        "read-only" if config.read_only else "read-modify",
+        "Starting gRPC server (access: %s; checkers: %s)",
+        ", ".join(al.name for al in access_levels),
+        ", ".join(str(cc) for cc in client_checkers),
     )
     service = ControlService(
         backend,
-        read_only=config.read_only,
-        client_checkers=list(_checkers(config)),
+        access_levels=access_levels,
+        client_checkers=client_checkers,
     )
     executor = concurrent.futures.ThreadPoolExecutor(
         max_workers=config.max_workers


### PR DESCRIPTION
Fixes: #196 

Clean up and fix issues with the selection of server-wide allowed access levels. First, the logging and debugability is improved. Then the logic that chooses if a server should be gloabally read only is fixed.