### PR TITLE
sambacc: fix share_info.tdb typo in _SRC_TDB_FILES

### DIFF
--- a/sambacc/ctdb.py
+++ b/sambacc/ctdb.py
@@ -737,7 +737,7 @@ _SRC_TDB_FILES = [
     "passdb.tdb",
     "registry.tdb",
     "secrets.tdb",
-    "share_info.td",
+    "share_info.tdb",
     "winbindd_idmap.tdb",
 ]
 


### PR DESCRIPTION
fixes https://github.com/samba-in-kubernetes/sambacc/issues/200