### PR TITLE
[RFC] sambacc: add merged configuration support

### DIFF
--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -162,6 +162,22 @@ def _check_config_valid(
                 raise
 
 
+def _merge(dst: dict, src: dict) -> None:
+    for key, value in src.items():
+        if key not in dst:
+            dst[key] = value
+            continue
+        dst_dict = isinstance(dst[key], dict)
+        src_dict = isinstance(value, dict)
+        if dst_dict and src_dict:
+            _merge(dst[key], value)
+            continue
+        if not dst_dict and not src_dict:
+            dst[key] = value
+            continue
+        raise ValueError(f"can not merge key {key!r} of {src!r} into {dst!r}")
+
+
 def read_config_files(
     fnames: list[str],
     *,
@@ -172,11 +188,11 @@ def read_config_files(
     At least one of the files from the fnames list must exist and contain
     a valid config. If none of the file names exist an error will be raised.
     """
-    # NOTE: Right now if more than one config exists they'll be "merged" but
-    # the merging is very simplistic right now. Mainly we expect that the
-    # users will be split from the main config (for security reasons) but
-    # it would be nicer to have a good merge algorithm handle everything
-    # smarter at some point.
+    # NOTE: If more than one config exists they'll be "merged" but the merging
+    # is very simplistic and ovewrites an entire top-level key's contents.  To
+    # be very backwards compatible this remains unchanged but we now support a
+    # "config:merged" key that does a recursive dict (only) merge - see
+    # GlobalConfig.load(...) for more details.
     opener = opener or FileOpener()
     gconfig = GlobalConfig()
     readfiles = set()
@@ -239,7 +255,10 @@ class GlobalConfig:
         _check_config_valid(
             data, _check_config_version(data), require_validation
         )
+        to_merge = data.pop("config:merge", None)
         self.data.update(data)
+        if to_merge:
+            _merge(self.data, to_merge)
 
     def get(self, ident: str) -> InstanceConfig:
         iconfig = self.data["configs"][ident]

--- a/sambacc/schema/conf-v0.schema.json
+++ b/sambacc/schema/conf-v0.schema.json
@@ -336,6 +336,41 @@
       "additionalProperties": {
         "type": "string"
       }
+    },
+    "config:merge": {
+      "type": "object",
+      "properties": {
+        "configs": {
+          "$ref": "#/properties/configs"
+        },
+        "shares": {
+          "$ref": "#/properties/shares"
+        },
+        "globals": {
+          "$ref": "#/properties/globals"
+        },
+        "domain_settings": {
+          "$ref": "#/properties/domain_settings"
+        },
+        "users": {
+          "$ref": "#/properties/users"
+        },
+        "groups": {
+          "$ref": "#/properties/groups"
+        },
+        "domain_users": {
+          "$ref": "#/properties/domain_users"
+        },
+        "domain_groups": {
+          "$ref": "#/properties/domain_groups"
+        },
+        "organizational_units": {
+          "$ref": "#/properties/organizational_units"
+        },
+        "ctdb": {
+          "$ref": "#/properties/ctdb"
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/sambacc/schema/conf-v0.schema.yaml
+++ b/sambacc/schema/conf-v0.schema.yaml
@@ -329,6 +329,29 @@ properties:
     type: object
     additionalProperties:
       type: string
+  "config:merge":
+    type: object
+    properties:
+      configs:
+        $ref: "#/properties/configs"
+      shares:
+        $ref: "#/properties/shares"
+      globals:
+        $ref: "#/properties/globals"
+      domain_settings:
+        $ref: "#/properties/domain_settings"
+      users:
+        $ref: "#/properties/users"
+      groups:
+        $ref: "#/properties/groups"
+      domain_users:
+        $ref: "#/properties/domain_users"
+      domain_groups:
+        $ref: "#/properties/domain_groups"
+      organizational_units:
+        $ref: "#/properties/organizational_units"
+      ctdb:
+        $ref: "#/properties/ctdb"
 additionalProperties: false
 required:
   - samba-container-config

--- a/sambacc/schema/conf_v0_schema.py
+++ b/sambacc/schema/conf_v0_schema.py
@@ -371,6 +371,23 @@ SCHEMA = {
             "type": "object",
             "additionalProperties": {"type": "string"},
         },
+        "config:merge": {
+            "type": "object",
+            "properties": {
+                "configs": {"$ref": "#/properties/configs"},
+                "shares": {"$ref": "#/properties/shares"},
+                "globals": {"$ref": "#/properties/globals"},
+                "domain_settings": {"$ref": "#/properties/domain_settings"},
+                "users": {"$ref": "#/properties/users"},
+                "groups": {"$ref": "#/properties/groups"},
+                "domain_users": {"$ref": "#/properties/domain_users"},
+                "domain_groups": {"$ref": "#/properties/domain_groups"},
+                "organizational_units": {
+                    "$ref": "#/properties/organizational_units"
+                },
+                "ctdb": {"$ref": "#/properties/ctdb"},
+            },
+        },
     },
     "additionalProperties": False,
     "required": ["samba-container-config"],

--- a/sambacc/schema/tool.py
+++ b/sambacc/schema/tool.py
@@ -38,7 +38,17 @@ def _format_black(path):
     # the --preview arg allows black to break up long strings that
     # the general check would discover and complain about. Otherwise
     # we'd be forced to ignore the formatting on these .py files.
-    subprocess.run(["black", "-l78", "--preview", path], check=True)
+    subprocess.run(
+        [
+            "black",
+            "-l78",
+            "--preview",
+            "--enable-unstable-feature",
+            "string_processing",
+            path,
+        ],
+        check=True,
+    )
 
 
 def match(files):


### PR DESCRIPTION
Add support for a "merged configuration" section. Currently, reading any new top-level configuration blocks from multiple config sources overwrites the existing section.  In other words: if configA and configB both have a top-level "shares" section only the content from configB appears in the final config.

In order to maintain existing behavior but allow for more flexible updates we add a new special "config:merge" config section. This config section contains all the same top-level keys as a typical sambacc configuration.

An example follows:
```
$ cat /tmp/foo 
{
  "samba-container-config": "v0",
  "configs": {
    "demo": {
      "shares": [
        "share"
      ],
      "globals": [
        "default"
      ],
      "instance_name": "SAMBA"
    }
  },
  "shares": {
    "share": {
      "options": {
        "path": "/share",
        "valid users": "sambauser, otheruser",
        "x:important": "extremely"
      }
    }
  },
  "globals": {
    "default": {
      "options": {
        "security": "user",
        "server min protocol": "SMB2",
        "load printers": "no",
        "printing": "bsd",
        "printcap name": "/dev/null",
        "disable spoolss": "yes",
        "guest ok": "no"
      }
    }
  },
  "users": {
    "all_entries": [
      {
        "name": "sambauser",
        "password": "samba"
      },
      {
        "name": "otheruser",
        "password": "insecure321"
      }
    ]
  },
  "_footer": 1
}

$ PYTHONPATH=. python -m sambacc.commands.main --id demo --config /tmp/foo   print-config
[global]
        security = user
        server min protocol = SMB2
        load printers = no
        printing = bsd
        printcap name = /dev/null
        disable spoolss = yes
        guest ok = no
        netbios name = SAMBA

[share]
        path = /share
        valid users = sambauser, otheruser
        x:important = extremely


$ cat /tmp/bar
{
  "samba-container-config": "v0",
  "config:merge": {
    "shares": {
      "share": {
        "options": {
          "x:mondo": "yes",
          "x:pondo": "always",
          "valid users": "sambauser, otheruser, rick"
        }
      }
    }
  },
  "_footer": 1
}

$ PYTHONPATH=. python -m sambacc.commands.main --id demo --config /tmp/foo --config /tmp/bar  print-config
[global]
        security = user
        server min protocol = SMB2
        load printers = no
        printing = bsd
        printcap name = /dev/null
        disable spoolss = yes
        guest ok = no
        netbios name = SAMBA

[share]
        path = /share
        valid users = sambauser, otheruser, rick
        x:important = extremely
        x:mondo = yes
        x:pondo = always
```
