### PR TITLE
pyproject.toml: Cap setuptools_scm<10.2 to fix CentOS Stream 9 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm>=6.0"]
+requires = ["setuptools>=42", "wheel", "setuptools_scm>=6.0,<10.2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
_setuptools_scm_ 10.2.0 uses the `ignore_egg_info_in_manifest` attribute from _setuptools_ 64.0.1 but doesn't declare that minimum in its own metadata. On CentOS Stream 9, the system provides _setuptools_ 53.0.0 which lacks this attribute, causing an AttributeError during sdist builds in tox. Raising the _setuptools_ floor is not an option because `%pyproject_buildrequires` resolves against system packages and CentOS Stream 9 does not ship _setuptools_>=64.

Cap _setuptools_scm_ below 10.2 until upstream fixes the missing version constraint.

fixes #204 