### PR TITLE
sambacc: always start watch loop with previous=None

### DIFF
--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -232,9 +232,12 @@ def update_config(ctx: Context) -> None:
     if ctx.cli.watch:
         _logger.info("will watch configuration source")
         waiter = best_waiter(ctx.cli.config)
+        # Pass None as initial_value so the first iteration always writes the
+        # current config to the samba registry, consistent with the non-watch
+        # code path which also passes None unconditionally.
         watch(
             waiter,
-            ctx.instance_config,
+            None,
             _get_config,
             trigger,
         )

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -227,6 +227,10 @@ def test_update_config_ctdb_notleader(tmp_path, monkeypatch):
 
 
 def test_update_config_watch_waiter_expires(tmp_path, monkeypatch):
+    # Verifies that watch mode performs an initial registry sync on the first
+    # iteration even when the config file hasn't changed since the process
+    # started.  Subsequent iterations with no config change must not trigger
+    # additional writes (only the initial sync happens).
     cfg_path = str(tmp_path / "config")
     fake = tmp_path / "fake.sh"
     chkpath = tmp_path / ".executed"
@@ -250,7 +254,12 @@ def test_update_config_watch_waiter_expires(tmp_path, monkeypatch):
     )
     sambacc.commands.config.update_config(ctx)
 
-    assert not os.path.exists(chkpath)
+    # The initial iteration compares against None so the registry is always
+    # written once on startup, regardless of whether the config changed.
+    assert os.path.exists(chkpath)
+    chk = open(chkpath).readlines()
+    assert any(("net" in line) for line in chk)
+    assert any(("smbcontrol" in line) for line in chk)
     assert fake_waiter.count == 5
 
 


### PR DESCRIPTION
`update-config --watch` passed `ctx.instance_config` as the initial previous into the watch loop. Because `ctx.instance_config` is loaded from the same full `SAMBACC_CONFIG` URI list (including config:merge stubs) as `_get_config()`, the first iteration always evaluated no change and the registry was never written on startup.

When a secondary `rados:mon-config-key` URI carrying a `config:merge` stub was added to `SAMBACC_CONFIG` (e.g. Ceph RGW credentials), the merged values never made it into the registry. `net conf list` showed empty, while 
`samba-container print-config` showed the correct merged output. 

This PR intends to fix this issue by passing `previous = None` for watch path as well which will now unconditionally trigger a registry write on the first iteration. 

Fixes: https://github.com/samba-in-kubernetes/sambacc/issues/208