### PR TITLE
ceph/rados: close cluster-meta connection on context exit

### DIFF
--- a/sambacc/ceph/rados.py
+++ b/sambacc/ceph/rados.py
@@ -188,6 +188,7 @@ class RADOSObjectRef(typing.IO):
             self._closed = True
         if self._connected:
             self._conn.shutdown()
+            self._connected = False
 
     @property
     def closed(self) -> bool:
@@ -354,8 +355,18 @@ class ClusterMetaRADOSHandle:
     def __exit__(
         self, exc_type: ExcType, exc_val: ExcValue, exc_tb: ExcTraceback
     ) -> None:
-        if self._locked:
-            self._rados_obj._unlock(self._lock_name, self._cookie)
+        try:
+            if self._locked:
+                self._rados_obj._unlock(self._lock_name, self._cookie)
+        finally:
+            # Always release the underlying RADOS connection. open() builds a
+            # fresh, fully-connected RADOSObjectRef for every context and no
+            # caller retains it past the `with` block, so failing to close
+            # here leaks one librados client (and its ~dozen threads) per
+            # invocation -- e.g. once per poll in
+            # ctdb.monitor_cluster_meta_changes(). Runs even if _unlock (or
+            # the with-body) raised; close() is idempotent.
+            self._rados_obj.close()
         return
 
 

--- a/tests/test_rados_leak.py
+++ b/tests/test_rados_leak.py
@@ -1,0 +1,102 @@
+#
+# sambacc: a samba container configuration tool
+# Copyright (C) 2026  John Mulligan
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>
+#
+
+import unittest.mock
+
+import pytest
+
+import sambacc.ceph.rados
+
+# CAUTION: these tests mock the ceph rados API. The fake Rados connection
+# counts connect/shutdown so we can assert that connections are released
+# rather than accumulated.
+
+
+@pytest.fixture(scope="function")
+def fake_cluster_meta(monkeypatch):
+    mock = unittest.mock.MagicMock()
+    # empty object body -> load() returns {}
+    mock.Rados.return_value.open_ioctx.return_value.read.return_value = b""
+    monkeypatch.setitem(sambacc.ceph.rados._module, "rados", mock)
+
+    interface = sambacc.ceph.rados._RADOSInterface()
+    interface.api = mock
+    interface.client_name = ""
+    interface.full_name = False
+    monkeypatch.setattr(
+        sambacc.ceph.rados._RADOSHandler, "_interface", interface
+    )
+
+    cmo = sambacc.ceph.rados.ClusterMetaRADOSObject.create_from_uri(
+        "rados://foo/bar/baz"
+    )
+    conn = mock.Rados.return_value
+    ioctx = conn.open_ioctx.return_value
+    return cmo, conn, ioctx
+
+
+def test_cluster_meta_open_closes_connection(fake_cluster_meta):
+    cmo, conn, ioctx = fake_cluster_meta
+
+    with cmo.open() as handle:
+        assert handle.load() == {}
+
+    assert conn.connect.call_count == 1
+    assert conn.shutdown.call_count == 1
+    assert ioctx.close.call_count == 1
+
+
+def test_cluster_meta_open_does_not_leak_across_iterations(fake_cluster_meta):
+    # ctdb.monitor_cluster_meta_changes() reopens once per poll; every open
+    # connects a fresh client, so connects and shutdowns must stay balanced.
+    cmo, conn, ioctx = fake_cluster_meta
+
+    iterations = 25
+    for _ in range(iterations):
+        with cmo.open(locked=True) as handle:
+            handle.load()
+
+    assert conn.connect.call_count == iterations
+    assert conn.shutdown.call_count == iterations
+    assert ioctx.close.call_count == iterations
+
+
+def test_cluster_meta_open_closes_when_body_raises(fake_cluster_meta):
+    cmo, conn, ioctx = fake_cluster_meta
+
+    with pytest.raises(RuntimeError):
+        with cmo.open(locked=True):
+            raise RuntimeError("boom")
+
+    assert ioctx.unlock.called
+    assert conn.shutdown.call_count == 1
+    assert ioctx.close.call_count == 1
+
+
+def test_rados_object_ref_close_is_idempotent():
+    mock = unittest.mock.MagicMock()
+    rr = sambacc.ceph.rados.RADOSObjectRef(mock, "foo", "bar", "baz")
+    conn = mock.Rados.return_value
+    ioctx = conn.open_ioctx.return_value
+
+    rr.close()
+    rr.close()
+    rr.close()
+
+    assert ioctx.close.call_count == 1
+    assert conn.shutdown.call_count == 1


### PR DESCRIPTION
## Summary

`ClusterMetaRADOSHandle.__exit__` never releases the RADOS connection it
opened. Every `ClusterMetaRADOSObject.open()` builds a brand-new, fully
`connect()`-ed `RADOSObjectRef` (one `rados.Rados()` client, which spawns
roughly a dozen librados threads), but the handle's context-manager exit only
drops the CTDB lock and returns. `RADOSObjectRef.close()` -- which calls
`ioctx.close()` and `conn.shutdown()` -- is therefore never invoked.

Because `ctdb.monitor_cluster_meta_changes()` opens this handle on every poll
(`with cmeta.open(locked=True) as cmo:`, ~once per minute, indefinitely), the
process leaks one fully-connected librados client per iteration. Threads and
memory grow without bound until the container is OOM-killed.

This PR makes the handle close its underlying object ref on exit, and makes
`RADOSObjectRef.close()` idempotent so it cannot double-`shutdown()`.

## Root cause

In `sambacc/ceph/rados.py`:

`ClusterMetaRADOSObject.open()` -> `_RADOSHandler.get_object()` ->
`RADOSObjectRef._from_uri(interface=self._interface, ...)`. Since `_interface`
is a `_RADOSInterface` (not a shared `RADOSConnection`), the ref takes the
`_open()` path:

```python
def _open(self, interface: _RADOSInterface) -> None:
    # TODO: connection caching
    self._api = interface.api
    self._conn = interface.Rados()
    self._conn.connect()
    self._connected = True
```

so each `open()` = one new connected client. The matching teardown exists on
the ref:

```python
def close(self) -> None:
    if not self._closed:
        self._ioctx.close()
        self._closed = True
    if self._connected:
        self._conn.shutdown()
```

but nothing calls it. The handle's exit is a no-op beyond unlocking:

```python
def __exit__(self, exc_type, exc_val, exc_tb) -> None:
    if self._locked:
        self._rados_obj._unlock(self._lock_name, self._cookie)
    return
```

No caller keeps the handle/ref alive past its `with` block. In `ctdb.py`
every consumer -- `monitor_cluster_meta_changes`, `add_node_to_cluster_meta`,
`refresh_node_in_cluster_meta`, `pnn_in_cluster_meta`, `_node_check`,
`_node_update`, `cluster_meta_to_nodes` -- uses the value returned by
`load()`/the effect of `dump()` and never touches the handle after the block.
Closing on exit is therefore safe: nothing relies on the connection persisting.

## The fix

`sambacc/ceph/rados.py`:

1. `ClusterMetaRADOSHandle.__exit__` now unlocks (when locked) inside a
   `try`, and closes the underlying ref in a `finally`. The `finally`
   guarantees the connection is freed even if `_unlock()` raises or the
   with-body raised (e.g. a failing `load()`):

   ```python
   def __exit__(self, exc_type, exc_val, exc_tb) -> None:
       try:
           if self._locked:
               self._rados_obj._unlock(self._lock_name, self._cookie)
       finally:
           self._rados_obj.close()
       return
   ```

2. `RADOSObjectRef.close()` now clears `self._connected` after shutting the
   connection down, so a second `close()` cannot call `shutdown()` twice:

   ```python
   if self._connected:
       self._conn.shutdown()
       self._connected = False
   ```

This is intentionally minimal and surgical -- it does not change how or when
connections are created, only that they are torn down when the handle's
context ends.

### Alternative / complementary direction

The connection churn itself (a fresh connect per poll) is the deeper cost; the
`# TODO: connection caching` note on `RADOSObjectRef._open()` points at the
better long-term fix: have `monitor_cluster_meta_changes()` (and friends) hold
one long-lived `RADOSConnection` and reuse it across iterations via the
existing `RADOSConnection.get_object()` / `_connected_to()` path, so each poll
reuses the socket instead of reconnecting. That is a larger, behavior-changing
refactor. This PR deliberately ships the small correctness fix -- stop leaking
-- and leaves connection caching as a follow-up.

## Reproduction

Observed on the master-head container image
`quay.io/samba.org/samba-server` digest `sha256:04d481b8...`, package version
`sambacc 0.10~4.gc989a9476` (repo commit `c989a9476`). Driving the exact
`monitor_cluster_meta_changes` open path in a loop:

```python
for _ in range(25):
    obj = ClusterMetaRADOSObject.create_from_uri("rados://<pool>/<ns>/<key>")
    with obj.open(locked=False) as cmo:
        cmo.load()
```

Thread count climbs monotonically by ~12 per iteration (one librados client's
worth), never dropping -- confirming a per-open connection leak. On a
long-running `ctdb-monitor-nodes` process this ends in host OOM. After the fix
the count is flat across iterations.

## Tests

`tests/test_rados_leak.py` (mirrors the mocking style of
`tests/test_rados_opener.py`; no real cluster required -- a `MagicMock`
stands in for the `rados` module and counts `connect`/`shutdown`/`close`):

- `test_cluster_meta_open_closes_connection` -- one `open()` cycle connects
  once and, on exit, shuts down + closes the ioctx exactly once.
- `test_cluster_meta_open_does_not_leak_across_iterations` -- the monitor-loop
  pattern over 25 iterations keeps `connect` and `shutdown` counts balanced
  (25 == 25). Fails on the current code (25 connects, 0 shutdowns).
- `test_cluster_meta_open_closes_when_body_raises` -- an exception in the
  with-body still unlocks and shuts the connection down.
- `test_rados_object_ref_close_is_idempotent` -- three `close()` calls result
  in exactly one `shutdown()`.

All four fail against `c989a9476` unpatched and pass with the fix applied.
The existing `tests/test_rados_opener.py` and `tests/test_ctdb.py` continue to
pass (31 passed total). `flake8` and `black --line-length 79` are clean on
both changed files.

## Verified on a live production node
In addition to the unit test, the fix was verified on a live cephadm SMB (CTDB) node (Ceph v20.2.2, image `quay.io/samba.org/samba-server:ceph20-centos-amd64`). With the patched `rados.py` bind-mounted over the installed module, an observer calling `ClusterMetaRADOSObject.open(locked=False)` every 5s held a **flat 1 thread across 74 iterations**, while an unpatched observer on the same node climbed **1 → 889 (+12 threads/iteration)** and the node's real `ctdb-monitor-nodes` daemon leaked at the **same +12/~68s** over the same window. The patch eliminates the leak.

Fixes #210
