### PR TITLE
config: Sync users and groups to passdb on config change

### DIFF
--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -109,7 +109,8 @@ def _update_config(
     boolean indicating if the instance configs differed.
     """
     # has the config changed?
-    changed = not current.same(previous, log_diff=_log_diff)
+    differences = current.compare(previous, log_diff=_log_diff)
+    changed = bool(differences)
     # ensure share paths exist
     if changed and ensure_paths:
         for share in current.shares():

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -126,6 +126,13 @@ def _update_config(
         _logger.info("Updating samba configuration")
         loader = nc.NetCmdLoader()
         loader.import_config(current)
+    # update users and groups if they changed
+    if config.DifferenceFlag.USERS_GROUPS in differences:
+        _logger.info("Updating users and groups")
+        from .users import sync_sys_users, sync_passdb_users
+
+        sync_sys_users(current)
+        sync_passdb_users(current)
     # notify smbd of changes
     if changed and notify_server:
         try:

--- a/sambacc/commands/users.py
+++ b/sambacc/commands/users.py
@@ -18,8 +18,36 @@
 
 import sambacc.passdb_loader as passdb
 import sambacc.passwd_loader as ugl
+from sambacc import config
 
 from .cli import commands, setup_steps, Context
+
+
+def sync_sys_users(
+    iconfig: config.InstanceConfig,
+    passwd_path: str = "/etc/passwd",
+    group_path: str = "/etc/group",
+) -> None:
+    """Import users and groups from an InstanceConfig to the passwd and
+    group files.
+    """
+    etc_passwd_loader = ugl.PasswdFileLoader(passwd_path)
+    etc_group_loader = ugl.GroupFileLoader(group_path)
+    etc_passwd_loader.read()
+    etc_group_loader.read()
+    for u in iconfig.users():
+        etc_passwd_loader.add_user(u)
+    for g in iconfig.groups():
+        etc_group_loader.add_group(g)
+    etc_passwd_loader.write()
+    etc_group_loader.write()
+
+
+def sync_passdb_users(iconfig: config.InstanceConfig) -> None:
+    """Import users into samba's passdb."""
+    smb_passdb_loader = passdb.PassDBLoader()
+    for u in iconfig.users():
+        smb_passdb_loader.add_user(u)
 
 
 @commands.command(name="import-users")
@@ -36,23 +64,14 @@ def import_sys_users(ctx: Context) -> None:
     """Import users and groups from sambacc config to the passwd and
     group files.
     """
-    etc_passwd_loader = ugl.PasswdFileLoader(ctx.cli.etc_passwd_path)
-    etc_group_loader = ugl.GroupFileLoader(ctx.cli.etc_group_path)
-
-    etc_passwd_loader.read()
-    etc_group_loader.read()
-    for u in ctx.instance_config.users():
-        etc_passwd_loader.add_user(u)
-    for g in ctx.instance_config.groups():
-        etc_group_loader.add_group(g)
-    etc_passwd_loader.write()
-    etc_group_loader.write()
+    sync_sys_users(
+        ctx.instance_config,
+        ctx.cli.etc_passwd_path,
+        ctx.cli.etc_group_path,
+    )
 
 
 @setup_steps.command("users_passdb")
 def import_passdb_users(ctx: Context) -> None:
     """Import users into samba's passdb."""
-    smb_passdb_loader = passdb.PassDBLoader()
-    for u in ctx.instance_config.users():
-        smb_passdb_loader.add_user(u)
-    return
+    sync_passdb_users(ctx.instance_config)

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -53,6 +53,7 @@ class DifferenceFlag(enum.Enum):
     KEYBRIDGE = 3
     SHARES = 4
     TYPE = 5
+    USERS_GROUPS = 6
 
 
 # the standard location for samba's smb.conf
@@ -434,6 +435,11 @@ class InstanceConfig:
         if self_kbridge != other_kbridge:
             log_diff("keybridge values differ", self_kbridge, other_kbridge)
             differences.add(DifferenceFlag.KEYBRIDGE)
+        self_ug = _users_groups_data(self.gconfig)
+        other_ug = _users_groups_data(other.gconfig)
+        if self_ug != other_ug:
+            log_diff("users/groups values differ", self_ug, other_ug)
+            differences.add(DifferenceFlag.USERS_GROUPS)
         return differences
 
     def same(
@@ -862,6 +868,13 @@ def _kbridge_data(obj: typing.Optional[KeyBridgeConfig]) -> dict:
     values = dict(obj._kbconf)
     values["__name"] = obj._name
     return values
+
+
+def _users_groups_data(gconfig: GlobalConfig) -> dict:
+    return {
+        "users": gconfig.data.get("users", {}),
+        "groups": gconfig.data.get("groups", {}),
+    }
 
 
 def _safe_split_host_port(host: str, scheme: str = "https") -> tuple[str, int]:

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -46,6 +46,15 @@ JSONData = dict[str, typing.Any]
 # differences back to a a higher level.
 LogDiffFunc = typing.Callable[[str, typing.Any, typing.Any], None]
 
+
+class DifferenceFlag(enum.Enum):
+    GLOBALS = 1
+    INSTANCE = 2
+    KEYBRIDGE = 3
+    SHARES = 4
+    TYPE = 5
+
+
 # the standard location for samba's smb.conf
 SMB_CONF = "/etc/samba/smb.conf"
 CLUSTER_META_JSON = "/var/lib/ctdb/shared/ctdb-nodes.json"
@@ -392,39 +401,48 @@ class InstanceConfig:
         config = self.gconfig.data.get("keybridge", {}).get(name, {})
         return KeyBridgeConfig(config, name=name)
 
+    def compare(
+        self,
+        other: typing.Any,
+        *,
+        log_diff: typing.Optional[LogDiffFunc] = None,
+    ) -> set[DifferenceFlag]:
+        if not log_diff:
+            log_diff = _no_op_log_diff
+        if not isinstance(other, InstanceConfig):
+            log_diff("not an InstanceConfig", self, other)
+            return {DifferenceFlag.TYPE}
+        differences: set[DifferenceFlag] = set()
+        if self.iconfig != other.iconfig:
+            log_diff(
+                "instance config values differ", self.iconfig, other.iconfig
+            )
+            differences.add(DifferenceFlag.INSTANCE)
+        self_shares = _shares_data(self.gconfig, self.iconfig)
+        other_shares = _shares_data(other.gconfig, other.iconfig)
+        if self_shares != other_shares:
+            log_diff("shares values differ", self_shares, other_shares)
+            differences.add(DifferenceFlag.SHARES)
+        self_globals = _globals_data(self.gconfig, self.iconfig)
+        other_globals = _globals_data(other.gconfig, other.iconfig)
+        if self_globals != other_globals:
+            log_diff("globals values differ", self_globals, other_globals)
+            differences.add(DifferenceFlag.GLOBALS)
+        # keybridge values are be held outside of the iconfig/gconfig
+        self_kbridge = _kbridge_data(self.keybridge_config())
+        other_kbridge = _kbridge_data(other.keybridge_config())
+        if self_kbridge != other_kbridge:
+            log_diff("keybridge values differ", self_kbridge, other_kbridge)
+            differences.add(DifferenceFlag.KEYBRIDGE)
+        return differences
+
     def same(
         self,
         other: typing.Any,
         *,
         log_diff: typing.Optional[LogDiffFunc] = None,
     ) -> bool:
-        if not log_diff:
-            log_diff = _no_op_log_diff
-        if not isinstance(other, InstanceConfig):
-            log_diff("not an InstanceConfig", self, other)
-            return False
-        if self.iconfig != other.iconfig:
-            log_diff(
-                "instance config values differ", self.iconfig, other.iconfig
-            )
-            return False
-        self_shares = _shares_data(self.gconfig, self.iconfig)
-        other_shares = _shares_data(other.gconfig, other.iconfig)
-        if self_shares != other_shares:
-            log_diff("shares values differ", self_shares, other_shares)
-            return False
-        self_globals = _globals_data(self.gconfig, self.iconfig)
-        other_globals = _globals_data(other.gconfig, other.iconfig)
-        if self_globals != other_globals:
-            log_diff("globals values differ", self_globals, other_globals)
-            return False
-        # keybridge values are be held outside of the iconfig/gconfig
-        self_kbridge = _kbridge_data(self.keybridge_config())
-        other_kbridge = _kbridge_data(other.keybridge_config())
-        if self_kbridge != other_kbridge:
-            log_diff("keybridge values differ", self_kbridge, other_kbridge)
-            return False
-        return True
+        return not self.compare(other, log_diff=log_diff)
 
     def __eq__(self, other: typing.Any) -> bool:
         return self.same(other)


### PR DESCRIPTION
_InstanceConfig.same()_ compared shares, globals, and keybridge but not users/groups, so `update-config --watch` never detected changes to user/group data. Additionally, _\_update_config()_ had no code path to re-import users into _/etc/passwd_ or samba's passdb even if a change were detected. This meant that runtime changes to users or groups in the configuration source were silently ignored by the config watcher - requiring a full container restart to take effect.

This PR refactors _InstanceConfig.same()_ by introducing a `DifferenceFlag` enum and a new _compare()_ method that returns a set of flags indicating which aspects of the configuration differ, rather than a simple boolean. It also extracts user sync logic into reusable _sync_sys_users()_ and _sync_passdb_users()_ functions callable without a CLI context. Finally, it adds users/groups comparison to _compare()_ and calls the sync functions from _\_update_config()_ when user/group data changes between iterations.