### PR TITLE
sambacc: don't crash configwatch upon smbcontrol notify failure

### DIFF
--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -127,9 +127,23 @@ def _update_config(
         loader.import_config(current)
     # notify smbd of changes
     if changed and notify_server:
-        subprocess.check_call(
-            list(samba_cmds.smbcontrol["smbd", "reload-config"])
-        )
+        try:
+            subprocess.check_call(
+                list(samba_cmds.smbcontrol["smbd", "reload-config"])
+            )
+        except subprocess.CalledProcessError as err:
+            # smbd may not be up yet (or restarting) and thus not
+            # reachable via smbcontrol. This is expected to resolve itself
+            # once smbd finishes starting, so don't let it crash the
+            # config watch loop.
+            _logger.warning(
+                "smbcontrol could not notify smbd of the updated"
+                " configuration (exit status %s); smbd may still be"
+                " starting up and will pick up the change once it is"
+                " running: %s",
+                err.returncode,
+                err,
+            )
     return current, changed
 
 

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -138,11 +138,13 @@ class FakeWaiter:
         self.count += 1
 
 
-def _gen_fake_cmd(fake_path, chkpath, pnn="0"):
+def _gen_fake_cmd(fake_path, chkpath, pnn="0", fail_cmd=None):
     with open(fake_path, "w") as fh:
         fh.write("#!/bin/sh\n")
         fh.write(f'echo "$@" >> {chkpath}\n')
         fh.write(f'[ "$1" = ctdb ] && echo {pnn}" " ; \n')
+        if fail_cmd:
+            fh.write(f'[ "$1" = "{fail_cmd}" ] && exit 1\n')
         fh.write("exit 0\n")
     os.chmod(fake_path, 0o755)
 
@@ -170,6 +172,39 @@ def test_update_config_changed(tmp_path, monkeypatch):
     chk = open(chkpath).readlines()
     assert any(("net" in line) for line in chk)
     assert any(("smbcontrol" in line) for line in chk)
+
+
+def test_update_config_smbcontrol_fails(tmp_path, monkeypatch, caplog):
+    # If smbd isn't reachable or still starting up, smbcontrol exits
+    # non-zero. That must be logged, not raised, so it doesn't crash the
+    # config watch loop.
+    cfg_path = str(tmp_path / "config")
+    fake = tmp_path / "fake.sh"
+    chkpath = tmp_path / ".executed"
+    _gen_fake_cmd(fake, str(chkpath), fail_cmd="smbcontrol")
+    monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
+
+    ctx = FakeContext.defaults(cfg_path)
+    with open(cfg_path, "w") as fh:
+        fh.write(config2)
+    monkeypatch.setattr(
+        sambacc.paths,
+        "ensure_share_dirs",
+        functools.partial(
+            sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
+        ),
+    )
+    with caplog.at_level("WARNING"):
+        sambacc.commands.config.update_config(ctx)
+
+    assert os.path.exists(chkpath)
+    chk = open(chkpath).readlines()
+    assert any(("net" in line) for line in chk)
+    assert any(("smbcontrol" in line) for line in chk)
+    assert any(
+        "smbcontrol could not notify smbd" in rec.message
+        for rec in caplog.records
+    )
 
 
 def test_update_config_changed_ctdb(tmp_path, monkeypatch):


### PR DESCRIPTION
smbcontrol `smbd reload-config` can fail with a non-zero exit if smbd hasn't finished starting yet (e.g. during a ceph orch redeploy), and thus crashes the configwatch process.  The PR intends to fix the crash by logging the notify failure instead, as anyways smbd will pickup the config (updated) upon its start.

Fixes: https://github.com/samba-in-kubernetes/sambacc/issues/213