### PR TITLE
support split passwd & groups files

### DIFF
--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -154,7 +154,10 @@ class CommandBuilder:
         def _wrapper(f):
             self._commands.append(
                 Command(
-                    name=name, cmd_func=f, arg_func=arg_func, cmd_help=cmd_help
+                    name=name,
+                    cmd_func=f,
+                    arg_func=arg_func,
+                    cmd_help=cmd_help,
                 )
             )
             return f

--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -28,6 +28,7 @@ from sambacc import leader
 from sambacc import permissions
 from sambacc import simple_waiter
 from sambacc.opener import Opener
+from sambacc.typelets import Self
 
 _INOTIFY_OK = True
 try:
@@ -283,6 +284,52 @@ def perms_handler(
     return permissions.InitPosixPermsHandler(
         path, config.status_xattr, options=config.options
     )
+
+
+class AltLocation:
+    def __init__(
+        self,
+        default_path: str,
+        mutable_path: str = "",
+        link_path: str = "",
+    ) -> None:
+        self.default_path = default_path
+        self.mutable_path = mutable_path
+        self.link_path = link_path
+
+    @property
+    def altfiles(self) -> bool:
+        return bool(self.mutable_path or self.link_path)
+
+    @property
+    def writable(self) -> str:
+        return self.mutable_path if self.mutable_path else self.default_path
+
+    @classmethod
+    def parse(cls, value: typing.Union[str, Self]) -> Self:
+        # hack to avoid nesting
+        if isinstance(value, cls):
+            return value
+        assert isinstance(value, str)
+        # no colons - assume simple path
+        if ":" not in value:
+            return cls(default_path=value)
+        # colon separated field - similar to container runtime -v (etc)
+        parts = value.split(":")
+        if not 2 <= len(parts) <= 3:
+            raise ValueError(f"invalid alt-location: {value!r}")
+        default_path = parts[0]
+        if parts[1].endswith("/"):
+            mutable_path = f'{parts[1]}{default_path.split("/")[-1]}'
+        else:
+            mutable_path = parts[1]
+        link_path = ""
+        if len(parts) == 3:
+            if parts[2].endswith("/"):
+                link_path = f'{parts[2]}{default_path.split("/")[-1]}'
+            else:
+                link_path = parts[2]
+        return cls(default_path, mutable_path, link_path)
 
 
 commands = CommandBuilder()

--- a/sambacc/commands/common.py
+++ b/sambacc/commands/common.py
@@ -90,7 +90,7 @@ class CommandContext:
 
 def split_entries(value: str) -> list[str]:
     """Split a env var up into separate strings. The string can be
-    an "old school" colon seperated list of values (like PATH).
+    an "old school" colon separated list of values (like PATH).
     Or, it can be JSON-formatted if it starts and ends with square
     brackets ('[...]'). Strings are the only permitted type within
     this JSON-formatted list.

--- a/sambacc/commands/common.py
+++ b/sambacc/commands/common.py
@@ -38,6 +38,9 @@ from .cli import Parser, ceph_id, AltLocation
 DEFAULT_CONFIG = "/etc/samba/container/config.json"
 DEFAULT_JOIN_MARKER = "/var/lib/samba/container-join-marker.json"
 
+_ETC_PASSWD = AltLocation("/etc/passwd")
+_ETC_GROUP = AltLocation("/etc/group")
+
 
 class CommandContext:
     """CLI Context for standard samba-container commands."""
@@ -165,6 +168,22 @@ def env_to_cli(cli: argparse.Namespace) -> None:
     from_env(cli, "samba_debug_level", "SAMBA_DEBUG_LEVEL")
     from_env(cli, "validate_config", "SAMBACC_VALIDATE_CONFIG")
     from_env(cli, "ceph_id", "SAMBACC_CEPH_ID", convert_value=ceph_id)
+    from_env(
+        cli,
+        "passwd_location",
+        "SAMBACC_PASSWD_LOCATION",
+        default_obj=_ETC_PASSWD,
+        convert_env=lambda v: AltLocation.parse(v) if v else None,
+        convert_value=None,
+    )
+    from_env(
+        cli,
+        "group_location",
+        "SAMBACC_GROUP_LOCATION",
+        default_obj=_ETC_GROUP,
+        convert_env=lambda v: AltLocation.parse(v) if v else None,
+        convert_value=None,
+    )
 
 
 def pre_action(cli: argparse.Namespace) -> None:
@@ -218,16 +237,24 @@ def global_args(parser: Parser) -> None:
         ),
     )
     parser.add_argument(
-        "--etc-passwd-path",
-        default=AltLocation("/etc/passwd"),
+        "--passwd-location",
+        "--etc-passwd-path",  # deprecated alias
+        default=_ETC_PASSWD,
         type=AltLocation.parse,
-        help="Specify a path for the passwd file.",
+        help=(
+            "Specify a path, or colon separated path-spec"
+            " <default>:<writable>[:<symlink>], for the passwd file."
+        ),
     )
     parser.add_argument(
-        "--etc-group-path",
-        default=AltLocation("/etc/group"),
+        "--group-location",
+        "--etc-group-path",  # deprecated alias
+        default=_ETC_GROUP,
         type=AltLocation.parse,
-        help="Specify a path for the group file.",
+        help=(
+            "Specify a path, or colon separated path-spec"
+            " <default>:<writable>[:<symlink>], for the group file."
+        ),
     )
     parser.add_argument(
         "--username",

--- a/sambacc/commands/common.py
+++ b/sambacc/commands/common.py
@@ -33,7 +33,7 @@ from sambacc import url_opener
 from sambacc.typelets import Self
 
 from . import skips
-from .cli import Parser, ceph_id
+from .cli import Parser, ceph_id, AltLocation
 
 DEFAULT_CONFIG = "/etc/samba/container/config.json"
 DEFAULT_JOIN_MARKER = "/var/lib/samba/container-join-marker.json"
@@ -219,12 +219,14 @@ def global_args(parser: Parser) -> None:
     )
     parser.add_argument(
         "--etc-passwd-path",
-        default="/etc/passwd",
+        default=AltLocation("/etc/passwd"),
+        type=AltLocation.parse,
         help="Specify a path for the passwd file.",
     )
     parser.add_argument(
         "--etc-group-path",
-        default="/etc/group",
+        default=AltLocation("/etc/group"),
+        type=AltLocation.parse,
         help="Specify a path for the group file.",
     )
     parser.add_argument(

--- a/sambacc/commands/common.py
+++ b/sambacc/commands/common.py
@@ -121,7 +121,8 @@ def from_env(
     ns: argparse.Namespace,
     var: str,
     ename: str,
-    default: typing.Any = None,
+    *,
+    default_obj: typing.Any = None,
     convert_env: typing.Optional[typing.Callable] = None,
     convert_value: typing.Optional[typing.Callable] = str,
 ) -> None:
@@ -130,7 +131,7 @@ def from_env(
     not directly provided.
     """
     value = getattr(ns, var, None)
-    if not value:
+    if not value or (default_obj is not None and value is default_obj):
         value = os.environ.get(ename, "")
         if convert_env is not None:
             value = convert_env(value)
@@ -150,7 +151,6 @@ def env_to_cli(cli: argparse.Namespace) -> None:
         "SAMBACC_CONFIG",
         convert_env=split_entries,
         convert_value=None,
-        default=DEFAULT_CONFIG,
     )
     from_env(
         cli,

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -134,8 +134,8 @@ def _update_config(
 
         sync_sys_users(
             current,
-            ctx.cli.etc_passwd_path,
-            ctx.cli.etc_group_path,
+            ctx.cli.passwd_location,
+            ctx.cli.group_location,
         )
         sync_passdb_users(current)
     # notify smbd of changes

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -98,6 +98,7 @@ UpdateFunc = typing.Callable[..., UpdateResult]
 
 
 def _update_config(
+    ctx: Context,
     current: config.InstanceConfig,
     previous: typing.Optional[config.InstanceConfig],
     ensure_paths: bool = True,
@@ -131,7 +132,11 @@ def _update_config(
         _logger.info("Updating users and groups")
         from .users import sync_sys_users, sync_passdb_users
 
-        sync_sys_users(current)
+        sync_sys_users(
+            current,
+            ctx.cli.etc_passwd_path,
+            ctx.cli.etc_group_path,
+        )
         sync_passdb_users(current)
     # notify smbd of changes
     if changed and notify_server:
@@ -241,13 +246,14 @@ class Trigger:
 @commands.command(name="update-config", arg_func=_update_config_args)
 def update_config(ctx: Context) -> None:
     _get_config = functools.partial(_read_config, ctx)
+    _uconfig = functools.partial(_update_config, ctx)
     trigger = Trigger()
 
     if ctx.instance_config.with_ctdb:
         _logger.info("enabling ctdb support: will check for leadership")
-        trigger.add("samba", _exec_if_leader(ctx, _update_config))
+        trigger.add("samba", _exec_if_leader(ctx, _uconfig))
     else:
-        trigger.add("samba", _update_config)
+        trigger.add("samba", _uconfig)
     if pids_dir := ctx.cli.signal_pids_dir:
         trigger.add("pids", functools.partial(_signal_pids_dir, pids_dir))
 

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -17,6 +17,7 @@
 #
 
 import argparse
+import dataclasses
 import functools
 import logging
 import os
@@ -26,9 +27,11 @@ import subprocess
 import sys
 import typing
 
+
 from sambacc import config
 from sambacc import samba_cmds
 from sambacc.simple_waiter import watch
+from sambacc.typelets import Self
 import sambacc.netcmd_loader as nc
 import sambacc.paths as paths
 
@@ -91,6 +94,56 @@ def _read_config(ctx: Context) -> config.InstanceConfig:
         require_validation=ctx.require_validation,
         opener=ctx.opener,
     ).get(ctx.cli.identity)
+
+
+@dataclasses.dataclass(frozen=True)
+class ChangeContext:
+    current: config.InstanceConfig
+    previous: typing.Optional[config.InstanceConfig] = None
+    differences: typing.Optional[set[config.DifferenceFlag]] = None
+    applied: int = 0
+
+    @property
+    def changed(self) -> bool:
+        return bool(self.differences)
+
+    @property
+    def updated(self) -> bool:
+        return bool(self.applied)
+
+    def _all_differences(self) -> set[config.DifferenceFlag]:
+        return set() if self.differences is None else self.differences
+
+    def match(
+        self,
+        flags: typing.Union[
+            config.DifferenceFlag, typing.Iterable[config.DifferenceFlag]
+        ],
+        *,
+        wildcard_type_diff: bool = True,
+    ) -> bool:
+        """Return true if any of the flags specified are in the differences
+        set. If wildcard_type_diff is true, it treats a type mismatch (e.g.
+        previous is None) as a flag match.
+        """
+        adiff = self._all_differences()
+        if wildcard_type_diff and config.DifferenceFlag.TYPE in adiff:
+            return True
+        if isinstance(flags, config.DifferenceFlag):
+            flags = [flags]
+        return any(f in adiff for f in flags)
+
+    def diff(self) -> Self:
+        # cached differences
+        if self.differences is not None:
+            return self
+        # no differences set yet, get fresh
+        differences = self.current.compare(self.previous, log_diff=_log_diff)
+        _logger.debug("config differences found: %r", differences)
+        return dataclasses.replace(self, differences=differences)
+
+    def set_applied(self) -> Self:
+        return dataclasses.replace(self, applied=self.applied + 1)
 
 
 UpdateResult = typing.Tuple[typing.Optional[config.InstanceConfig], bool]

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -214,20 +214,29 @@ def _samba_config(chctx: ChangeContext) -> ChangeContext:
 
 
 def _ctr_users_groups(ctx: Context, chctx: ChangeContext) -> ChangeContext:
-    """Update host (container) defined users and groups if the users/groups
-    have changed.
+    """Update host (container) defined users and groups (passwd file) if the
+    users/groups have changed.
     """
     if not chctx.match(config.DifferenceFlag.USERS_GROUPS):
         return chctx
 
     # update users and groups if they changed
     _logger.info("Updating users and groups")
-
     sync_sys_users(
         chctx.current,
         ctx.cli.passwd_location,
         ctx.cli.group_location,
     )
+    return chctx.set_applied()
+
+
+def _sync_passdb(ctx: Context, chctx: ChangeContext) -> ChangeContext:
+    """Update samba's passdb if the users/groups have changed."""
+    if not chctx.match(config.DifferenceFlag.USERS_GROUPS):
+        return chctx
+
+    # update users and groups if they changed
+    _logger.info("Updating samba passdb")
     sync_passdb_users(chctx.current)
     return chctx.set_applied()
 
@@ -317,6 +326,7 @@ def update_config(ctx: Context) -> None:
     )
     cb_samba_config = _samba_config
     cb_ctr_users_groups = functools.partial(_ctr_users_groups, ctx)
+    cb_passdb = functools.partial(_sync_passdb, ctx)
     trigger = Trigger()
 
     if ctx.instance_config.with_ctdb:
@@ -324,10 +334,12 @@ def update_config(ctx: Context) -> None:
         cb_share_paths_shared = functools.partial(
             _when_leader, cb_share_paths_shared
         )
+        cb_passdb = functools.partial(_when_leader, cb_passdb)
         cb_samba_config = functools.partial(_when_leader, cb_samba_config)
     trigger.add("paths_shared", cb_share_paths_shared)
     trigger.add("paths_local", cb_share_paths_local)
     trigger.add("users_groups", cb_ctr_users_groups)
+    trigger.add("sync_passdb", cb_passdb)
     trigger.add("samba", cb_samba_config)
     if pids_dir := ctx.cli.signal_pids_dir:
         trigger.add("pids", functools.partial(_signal_pids_dir, pids_dir))

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -43,6 +43,7 @@ from .cli import (
     perms_handler,
     setup_steps,
 )
+from .users import sync_sys_users, sync_passdb_users
 
 _logger = logging.getLogger(__name__)
 
@@ -96,6 +97,14 @@ def _read_config(ctx: Context) -> config.InstanceConfig:
     ).get(ctx.cli.identity)
 
 
+def _readpid(path: pathlib.Path) -> int:
+    try:
+        return int(path.read_text())
+    except Exception as err:
+        _logger.warning("Unable to read pid file %r: %s", path, err)
+        return -1
+
+
 @dataclasses.dataclass(frozen=True)
 class ChangeContext:
     current: config.InstanceConfig
@@ -146,109 +155,73 @@ class ChangeContext:
         return dataclasses.replace(self, applied=self.applied + 1)
 
 
-UpdateResult = typing.Tuple[typing.Optional[config.InstanceConfig], bool]
-UpdateFunc = typing.Callable[..., UpdateResult]
+ChangeCheck = typing.Callable[[ChangeContext], ChangeContext]
 
 
-def _update_config(
-    ctx: Context,
-    current: config.InstanceConfig,
-    previous: typing.Optional[config.InstanceConfig],
-    ensure_paths: bool = True,
-    notify_server: bool = True,
-) -> UpdateResult:
-    """Compare the current and previous instance configurations. If they
-    differ, ensure any new paths, update the samba config, and inform any
-    running smbds of the new configuration.  Return the current config and a
-    boolean indicating if the instance configs differed.
-    """
-    # has the config changed?
-    differences = current.compare(previous, log_diff=_log_diff)
-    changed = bool(differences)
-    # ensure share paths exist
-    if changed and ensure_paths:
-        for share in current.shares():
-            path = share.path()
-            if not path:
-                continue
-            _logger.info(f"Ensuring share path: {path}")
-            paths.ensure_share_dirs(path)
-            _logger.info(f"Updating permissions if needed: {path}")
-            perms_handler(share.permissions_config(), path).update()
-    # update smb config
-    if changed:
-        _logger.info("Updating samba configuration")
-        loader = nc.NetCmdLoader()
-        loader.import_config(current)
-    # update users and groups if they changed
-    if config.DifferenceFlag.USERS_GROUPS in differences:
-        _logger.info("Updating users and groups")
-        from .users import sync_sys_users, sync_passdb_users
-
-        sync_sys_users(
-            current,
-            ctx.cli.passwd_location,
-            ctx.cli.group_location,
-        )
-        sync_passdb_users(current)
-    # notify smbd of changes
-    if changed and notify_server:
-        try:
-            subprocess.check_call(
-                list(samba_cmds.smbcontrol["smbd", "reload-config"])
-            )
-        except subprocess.CalledProcessError as err:
-            # smbd may not be up yet (or restarting) and thus not
-            # reachable via smbcontrol. This is expected to resolve itself
-            # once smbd finishes starting, so don't let it crash the
-            # config watch loop.
-            _logger.warning(
-                "smbcontrol could not notify smbd of the updated"
-                " configuration (exit status %s); smbd may still be"
-                " starting up and will pick up the change once it is"
-                " running: %s",
-                err.returncode,
-                err,
-            )
-    return current, changed
+def _share_paths(chctx: ChangeContext) -> ChangeContext:
+    if not chctx.changed:
+        return chctx
+    # TODO: would we only ensure paths on the leader?
+    # TODO: does this do something on non-fs backed shares (like cephfs)?
+    for share in chctx.current.shares():
+        path = share.path()
+        if not path:
+            continue
+        _logger.info(f"Ensuring share path: {path}")
+        paths.ensure_share_dirs(path)
+        _logger.info(f"Updating permissions if needed: {path}")
+        perms_handler(share.permissions_config(), path).update()
+    return chctx.set_applied()
 
 
-def _exec_if_leader(ctx: Context, cond_func: UpdateFunc) -> UpdateFunc:
-    """Run the cond func only on "nodes" that are the cluster leader."""
-
-    # CTDB status and leader detection is not changeable at runtime.
-    # we do not need to account for it changing in the updated config file(s)
-    @functools.wraps(cond_func)
-    def _call_if_leader(
-        current: config.InstanceConfig, previous: config.InstanceConfig
-    ) -> UpdateResult:
-        with best_leader_locator(ctx.instance_config) as ll:
-            if not ll.is_leader():
-                _logger.info("skipping config update. node not leader")
-                return None, False
-            _logger.info("checking for update. node is leader")
-            result = cond_func(current, previous)
-        return result
-
-    return _call_if_leader
-
-
-def _readpid(path: pathlib.Path) -> int:
+def _samba_config(chctx: ChangeContext) -> ChangeContext:
+    if not chctx.changed:
+        return chctx
+    _logger.info("Updating samba configuration")
+    loader = nc.NetCmdLoader()
+    loader.import_config(chctx.current)
     try:
-        return int(path.read_text())
-    except Exception as err:
-        _logger.warning("Unable to read pid file %r: %s", path, err)
-        return -1
+        subprocess.check_call(
+            list(samba_cmds.smbcontrol["smbd", "reload-config"])
+        )
+    except subprocess.CalledProcessError as err:
+        # smbd may not be up yet (or restarting) and thus not
+        # reachable via smbcontrol. This is expected to resolve itself
+        # once smbd finishes starting, so don't let it crash the
+        # config watch loop.
+        _logger.warning(
+            "smbcontrol could not notify smbd of the updated"
+            " configuration (exit status %s); smbd may still be"
+            " starting up and will pick up the change once it is"
+            " running: %s",
+            err.returncode,
+            err,
+        )
+    return chctx.set_applied()
 
 
-def _signal_pids_dir(
-    pids_dir: str,
-    current: config.InstanceConfig,
-    previous: typing.Optional[config.InstanceConfig],
-) -> UpdateResult:
-    changed = not current.same(previous, log_diff=_log_diff)
-    if not changed:
-        return current, changed
+def _ctr_users_groups(ctx: Context, chctx: ChangeContext) -> ChangeContext:
+    """Update host (container) defined users and groups if the users/groups
+    have changed.
+    """
+    if not chctx.match(config.DifferenceFlag.USERS_GROUPS):
+        return chctx
+
+    # update users and groups if they changed
+    _logger.info("Updating users and groups")
+
+    sync_sys_users(
+        chctx.current,
+        ctx.cli.passwd_location,
+        ctx.cli.group_location,
+    )
+    sync_passdb_users(chctx.current)
+    return chctx.set_applied()
+
+
+def _signal_pids_dir(pids_dir: str, chctx: ChangeContext) -> ChangeContext:
+    if not chctx.changed:
+        return chctx
 
     # something changed, send signal to pids found in pid files in dir
     try:
@@ -259,7 +232,7 @@ def _signal_pids_dir(
         ]
     except FileNotFoundError:
         _logger.warning("pids dir not found: %r; skipping pids", pids_dir)
-        return current, changed
+        return chctx
 
     pids = [pid for pid in _pids if pid > 0]  # filter out errors
     if pids != _pids:
@@ -271,51 +244,76 @@ def _signal_pids_dir(
             os.kill(pid, signal.SIGHUP)
         except OSError as err:
             _logger.warning("Failed to SIGHUP %d: %s", pid, err)
-    return current, changed
+    return chctx.set_applied()
+
+
+def _when_leader(cb: ChangeCheck, chctx: ChangeContext) -> ChangeContext:
+    # NOTE: it's important to maintain leader status while running the callback
+    # thus the context manager.
+    # CTDB enablement and the need for leader detection should not change
+    # while the process is running. Thus, _when_leader can wrap all future uses
+    # of a change check.
+    cbname = getattr(cb, "__name__", "")
+    if not cbname and hasattr(cb, "func"):
+        cbname = getattr(cb.func, "__name__", f"?{cb}")
+    with best_leader_locator(chctx.current) as ll:
+        if not ll.is_leader():
+            _logger.info("skipping %s. node not leader", cbname)
+            return chctx
+        _logger.info("executing %s. node is leader", cbname)
+        return cb(chctx)
+    return chctx
 
 
 class Trigger:
     def __init__(self) -> None:
-        self._actions: list[tuple[str, UpdateFunc]] = []
+        self._actions: list[tuple[str, ChangeCheck]] = []
 
-    def add(self, name: str, fn: UpdateFunc) -> None:
+    def add(self, name: str, fn: ChangeCheck) -> None:
         self._actions.append((name, fn))
+
+    def apply(self, chctx: ChangeContext) -> ChangeContext:
+        for name, cb in self._actions:
+            _logger.debug("Config change callback: %r", name)
+            chctx = cb(chctx.diff())
+            _logger.debug(
+                "Callback: %r: changed: %r, applied: %r",
+                name,
+                chctx.changed,
+                chctx.applied,
+            )
+        return chctx
 
     def __call__(
         self,
         current: config.InstanceConfig,
         previous: typing.Optional[config.InstanceConfig],
-    ) -> UpdateResult:
-        changed = False
-        for name, cb in self._actions:
-            _logger.debug("Config change callback: %r", name)
-            cfg, chg = cb(current, previous)
-            _logger.debug("Callback: %r: changed: %r", name, chg)
-            current = cfg if cfg else current
-            changed = changed or chg
-        return current, changed
+    ) -> tuple[config.InstanceConfig, bool]:
+        rctx = self.apply(ChangeContext(current=current, previous=previous))
+        return current, rctx.updated
 
 
 @commands.command(name="update-config", arg_func=_update_config_args)
 def update_config(ctx: Context) -> None:
     _get_config = functools.partial(_read_config, ctx)
-    _uconfig = functools.partial(_update_config, ctx)
+    cb_share_paths = _share_paths
+    cb_samba_config = _samba_config
+    cb_ctr_users_groups = functools.partial(_ctr_users_groups, ctx)
     trigger = Trigger()
 
     if ctx.instance_config.with_ctdb:
         _logger.info("enabling ctdb support: will check for leadership")
-        trigger.add("samba", _exec_if_leader(ctx, _uconfig))
-    else:
-        trigger.add("samba", _uconfig)
+        cb_share_paths = functools.partial(_when_leader, cb_share_paths)
+        cb_samba_config = functools.partial(_when_leader, cb_samba_config)
+    trigger.add("paths", cb_share_paths)
+    trigger.add("users_groups", cb_ctr_users_groups)
+    trigger.add("samba", cb_samba_config)
     if pids_dir := ctx.cli.signal_pids_dir:
         trigger.add("pids", functools.partial(_signal_pids_dir, pids_dir))
 
     if ctx.cli.watch:
         _logger.info("will watch configuration source")
         waiter = best_waiter(ctx.cli.config)
-        # Pass None as initial_value so the first iteration always writes the
-        # current config to the samba registry, consistent with the non-watch
-        # code path which also passes None unconditionally.
         watch(
             waiter,
             None,
@@ -323,7 +321,5 @@ def update_config(ctx: Context) -> None:
             trigger,
         )
     else:
-        # we pass None as the previous config so that the command is
-        # not nearly always a no-op when run from the command line.
-        trigger(_get_config(), None)
+        trigger.apply(ChangeContext(current=_get_config()))
     return

--- a/sambacc/commands/config.py
+++ b/sambacc/commands/config.py
@@ -154,16 +154,29 @@ class ChangeContext:
     def set_applied(self) -> Self:
         return dataclasses.replace(self, applied=self.applied + 1)
 
+    def shares_by_origin(
+        self, origin: config.ShareOrigin
+    ) -> list[config.ShareConfig]:
+        return [s for s in self.current.shares() if s.meta().origin is origin]
+
 
 ChangeCheck = typing.Callable[[ChangeContext], ChangeContext]
 
 
-def _share_paths(chctx: ChangeContext) -> ChangeContext:
-    if not chctx.changed:
+def _share_paths(
+    origin: config.ShareOrigin, chctx: ChangeContext
+) -> ChangeContext:
+    """Iterate over shares matching the given origin type, ensuring the paths
+    and permissions are set up.
+    Shares are separated by origin in order to only run this function on
+    the appropriate node(s).
+    For example: Shares in the local origin can, and should, be set up on all
+    nodes in a CTDB cluster while shares in the shared origin should only be
+    set up once (by the leader).
+    """
+    if not chctx.match(config.DifferenceFlag.SHARES):
         return chctx
-    # TODO: would we only ensure paths on the leader?
-    # TODO: does this do something on non-fs backed shares (like cephfs)?
-    for share in chctx.current.shares():
+    for share in chctx.shares_by_origin(origin):
         path = share.path()
         if not path:
             continue
@@ -296,16 +309,24 @@ class Trigger:
 @commands.command(name="update-config", arg_func=_update_config_args)
 def update_config(ctx: Context) -> None:
     _get_config = functools.partial(_read_config, ctx)
-    cb_share_paths = _share_paths
+    cb_share_paths_local = functools.partial(
+        _share_paths, config.ShareOrigin.LOCAL
+    )
+    cb_share_paths_shared = functools.partial(
+        _share_paths, config.ShareOrigin.SHARED
+    )
     cb_samba_config = _samba_config
     cb_ctr_users_groups = functools.partial(_ctr_users_groups, ctx)
     trigger = Trigger()
 
     if ctx.instance_config.with_ctdb:
         _logger.info("enabling ctdb support: will check for leadership")
-        cb_share_paths = functools.partial(_when_leader, cb_share_paths)
+        cb_share_paths_shared = functools.partial(
+            _when_leader, cb_share_paths_shared
+        )
         cb_samba_config = functools.partial(_when_leader, cb_samba_config)
-    trigger.add("paths", cb_share_paths)
+    trigger.add("paths_shared", cb_share_paths_shared)
+    trigger.add("paths_local", cb_share_paths_local)
     trigger.add("users_groups", cb_ctr_users_groups)
     trigger.add("samba", cb_samba_config)
     if pids_dir := ctx.cli.signal_pids_dir:

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -32,7 +32,10 @@ _logger = logging.getLogger(__name__)
 
 
 @setup_steps.command("nsswitch")
-def _import_nsswitch(ctx: Context) -> None:
+def _enable_nsswitch_winbind(ctx: Context) -> None:
+    """Unconditionally enable winbind support for passwd, group in the
+    nsswitch.conf file.
+    """
     # for compatibility with older versions the 'nsswitch' setup action always
     # enables winbind unconditionally
     nss = nsswitch.find()
@@ -41,13 +44,31 @@ def _import_nsswitch(ctx: Context) -> None:
         nss.write(nsswitch.NSSWITCH_DEST)
 
 
+@setup_steps.command("nsswitch_altfiles")
+def _enable_nsswitch_altfiles(ctx: Context) -> None:
+    """Unconditionally enable altfiles support for passwd, group in the
+    nsswitch.conf file.
+    """
+    nss = nsswitch.find()
+    if not nss.altfiles_enabled():
+        nss.ensure_altfiles_enabled()
+        nss.write(nsswitch.NSSWITCH_DEST)
+
+
 @setup_steps.command("nsswitch_auto")
 def _auto_choose_nsswitch(ctx: Context) -> None:
     # wrapper for the above 'nsswitch' setup action that is conditional on
-    # having ads security enabled in the samba config for this instance
-    if not ctx.instance_config.ads_security_configured:
+    # other inputs such as having ads security enabled in the samba config or
+    # having alternate paths for passwd set.
+    if ctx.instance_config.ads_security_configured:
+        _logger.debug("configuring nsswitch.conf for winbind")
+        _enable_nsswitch_winbind(ctx)
         return
-    _import_nsswitch(ctx)
+    if ctx.cli.passwd_location.altfiles or ctx.cli.group_location.altfiles:
+        _logger.debug("configuring nsswitch.conf for altfiles")
+        _enable_nsswitch_altfiles(ctx)
+        return
+    _logger.debug("no nsswitch.conf configuration needed")
 
 
 @setup_steps.command("smb_ctdb")

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -33,11 +33,21 @@ _logger = logging.getLogger(__name__)
 
 @setup_steps.command("nsswitch")
 def _import_nsswitch(ctx: Context) -> None:
-    # should nsswitch validation/edit be conditional only on ads?
+    # for compatibility with older versions the 'nsswitch' setup action always
+    # enables winbind unconditionally
     nss = nsswitch.find()
     if not nss.winbind_enabled():
         nss.ensure_winbind_enabled()
         nss.write(nsswitch.NSSWITCH_DEST)
+
+
+@setup_steps.command("nsswitch_auto")
+def _auto_choose_nsswitch(ctx: Context) -> None:
+    # wrapper for the above 'nsswitch' setup action that is conditional on
+    # having ads security enabled in the samba config for this instance
+    if not ctx.instance_config.ads_security_configured:
+        return
+    _import_nsswitch(ctx)
 
 
 @setup_steps.command("smb_ctdb")
@@ -95,7 +105,7 @@ _default_setup_steps = [
     "users",
     "smb_ctdb",
     "users_passdb",
-    "nsswitch",
+    "nsswitch_auto",
 ]
 
 

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -34,19 +34,10 @@ _logger = logging.getLogger(__name__)
 @setup_steps.command("nsswitch")
 def _import_nsswitch(ctx: Context) -> None:
     # should nsswitch validation/edit be conditional only on ads?
-    paths = ["/etc/nsswitch.conf", "/usr/etc/nsswitch.conf"]
-    for path in paths:
-        nss = nsswitch.NameServiceSwitchLoader(path)
-        try:
-            nss.read()
-            if not nss.winbind_enabled():
-                nss.ensure_winbind_enabled()
-                nss.write("/etc/nsswitch.conf")
-            return
-        except FileNotFoundError:
-            pass
-
-    raise FileNotFoundError(f"Failed to open {' or '.join(paths)}")
+    nss = nsswitch.find()
+    if not nss.winbind_enabled():
+        nss.ensure_winbind_enabled()
+        nss.write(nsswitch.NSSWITCH_DEST)
 
 
 @setup_steps.command("smb_ctdb")

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -102,10 +102,10 @@ def ensure_share_paths(ctx: Context) -> None:
 
 _default_setup_steps = [
     "config",
-    "users",
     "smb_ctdb",
-    "users_passdb",
     "nsswitch_auto",
+    "users",
+    "users_passdb",
 ]
 
 

--- a/sambacc/commands/main.py
+++ b/sambacc/commands/main.py
@@ -21,7 +21,7 @@ import typing
 
 from . import config as config_cmds
 from . import skips
-from .cli import commands, Fail
+from .cli import commands, CommandBuilder, Fail
 from .common import (
     CommandContext,
     enable_logging,
@@ -37,7 +37,12 @@ def main(args: typing.Optional[typing.Sequence[str]] = None) -> None:
     commands.include_multiple(
         [".check", ".ctdb", ".dns", ".initialize", ".join", ".run", ".users"]
     )
+    return main_command(commands, args)
 
+
+def main_command(
+    commands: CommandBuilder, args: typing.Optional[typing.Sequence[str]]
+) -> None:
     cli = commands.assemble(arg_func=global_args).parse_args(args)
     env_to_cli(cli)
     enable_logging(cli)

--- a/sambacc/commands/run.py
+++ b/sambacc/commands/run.py
@@ -36,7 +36,8 @@ INIT_ALL = "init-all"
 SMBD = "smbd"
 WINBINDD = "winbindd"
 CTDBD = "ctdbd"
-TARGETS = [SMBD, WINBINDD, CTDBD]
+CONFIGWATCH = "configwatch"
+TARGETS = [SMBD, WINBINDD, CTDBD, CONFIGWATCH]
 
 
 class WaitForCTDBCondition:
@@ -99,6 +100,16 @@ def _run_container_args(parser):
             " Based on env vars JOIN_USERNAME and INSECURE_JOIN_PASSWORD."
         ),
     )
+    # XXX: HACK - for embedded configwatch (starts with --config-watch- for
+    # pseudo namespacing)
+    parser.add_argument(
+        "--config-watch-signal-pids-dir",
+        dest="signal_pids_dir",
+        help=(
+            "Directory storing pid files."
+            " PIDs saved in files will be sent SIGHUP on config change."
+        ),
+    )
     parser.add_argument(
         "target",
         choices=TARGETS,
@@ -154,5 +165,19 @@ def run_container(ctx: Context) -> None:
         samba_cmds.execute(samba_cmds.winbindd_foreground())
     elif ctx.cli.target == "ctdbd":
         samba_cmds.execute(samba_cmds.ctdbd_foreground)
+    elif ctx.cli.target == CONFIGWATCH:
+        _wrap_configwatch(ctx)
     else:
         raise Fail(f"invalid target process: {ctx.cli.target}")
+
+
+def _wrap_configwatch(ctx: Context) -> None:
+    """Start configwatch (update-config --watch) via the run command instead of
+    the normal path, allowing configwatch to "steal" the setup capabilties of
+    the run subcommand without needing to do a huge refactoring of the command
+    handling/--setup args.
+    """
+    import sambacc.commands.config
+
+    ctx.cli.watch = True
+    sambacc.commands.config.update_config(ctx)

--- a/sambacc/commands/users.py
+++ b/sambacc/commands/users.py
@@ -16,23 +16,36 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 
+import typing
+
+import sambacc.nsswitch_loader as nsswitch
 import sambacc.passdb_loader as passdb
 import sambacc.passwd_loader as ugl
 from sambacc import config
+from sambacc import paths
 
-from .cli import commands, setup_steps, Context
+from .cli import commands, setup_steps, Context, AltLocation
 
 
 def sync_sys_users(
     iconfig: config.InstanceConfig,
-    passwd_path: str = "/etc/passwd",
-    group_path: str = "/etc/group",
+    passwd_location: AltLocation,
+    group_location: AltLocation,
+    nsswitch_location: typing.Optional[AltLocation] = None,
 ) -> None:
     """Import users and groups from an InstanceConfig to the passwd and
     group files.
     """
-    etc_passwd_loader = ugl.PasswdFileLoader(passwd_path)
-    etc_group_loader = ugl.GroupFileLoader(group_path)
+    if passwd_location.altfiles or group_location.altfiles:
+        if not nsswitch_location:
+            nsswitch_location = AltLocation(nsswitch.NSSWITCH_DEST)
+        nss = nsswitch.find()
+        if not nss.altfiles_enabled():
+            nss.ensure_altfiles_enabled()
+            nss.write(nsswitch_location.writable)
+
+    etc_passwd_loader = ugl.PasswdFileLoader(passwd_location.writable)
+    etc_group_loader = ugl.GroupFileLoader(group_location.writable)
     etc_passwd_loader.read()
     etc_group_loader.read()
     for u in iconfig.users():
@@ -41,6 +54,15 @@ def sync_sys_users(
         etc_group_loader.add_group(g)
     etc_passwd_loader.write()
     etc_group_loader.write()
+
+    # let os errors bubble up here. we want to stop if we can't create these
+    # necessary links
+    if passwd_location.link_path:
+        paths.ensure_symlink(
+            passwd_location.writable, passwd_location.link_path
+        )
+    if group_location.link_path:
+        paths.ensure_symlink(group_location.writable, group_location.link_path)
 
 
 def sync_passdb_users(iconfig: config.InstanceConfig) -> None:

--- a/sambacc/commands/users.py
+++ b/sambacc/commands/users.py
@@ -100,8 +100,8 @@ def import_sys_users(ctx: Context) -> None:
     """
     sync_sys_users(
         ctx.instance_config,
-        ctx.cli.etc_passwd_path,
-        ctx.cli.etc_group_path,
+        ctx.cli.passwd_location,
+        ctx.cli.group_location,
     )
 
 

--- a/sambacc/commands/users.py
+++ b/sambacc/commands/users.py
@@ -16,9 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 
-import typing
-
-import sambacc.nsswitch_loader as nsswitch
 import sambacc.passdb_loader as passdb
 import sambacc.passwd_loader as ugl
 from sambacc import config
@@ -31,19 +28,10 @@ def sync_sys_users(
     iconfig: config.InstanceConfig,
     passwd_location: AltLocation,
     group_location: AltLocation,
-    nsswitch_location: typing.Optional[AltLocation] = None,
 ) -> None:
     """Import users and groups from an InstanceConfig to the passwd and
     group files.
     """
-    if passwd_location.altfiles or group_location.altfiles:
-        if not nsswitch_location:
-            nsswitch_location = AltLocation(nsswitch.NSSWITCH_DEST)
-        nss = nsswitch.find()
-        if not nss.altfiles_enabled():
-            nss.ensure_altfiles_enabled()
-            nss.write(nsswitch_location.writable)
-
     etc_passwd_loader = ugl.PasswdFileLoader(passwd_location.writable)
     etc_group_loader = ugl.GroupFileLoader(group_location.writable)
     try:

--- a/sambacc/commands/users.py
+++ b/sambacc/commands/users.py
@@ -46,8 +46,20 @@ def sync_sys_users(
 
     etc_passwd_loader = ugl.PasswdFileLoader(passwd_location.writable)
     etc_group_loader = ugl.GroupFileLoader(group_location.writable)
-    etc_passwd_loader.read()
-    etc_group_loader.read()
+    try:
+        etc_passwd_loader.read()
+    except FileNotFoundError:
+        # if we are not using altfiles we expect an existing readable passwd
+        # file. re-raise the exception if we are not using altfiles
+        if not passwd_location.altfiles:
+            raise
+    try:
+        etc_group_loader.read()
+    except FileNotFoundError:
+        # if we are not using altfiles we expect an existing readable group
+        # file. re-raise the exception if we are not using altfiles
+        if not group_location.altfiles:
+            raise
     for u in iconfig.users():
         etc_passwd_loader.add_user(u)
     for g in iconfig.groups():

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -325,6 +325,12 @@ class InstanceConfig:
             yield uentry.vgroup()
 
     @property
+    def ads_security_configured(self) -> bool:
+        # TODO: refactor global_options so a lookup is more efficient
+        opts = dict(self.global_options())
+        return opts.get("security", "") == "ads"
+
+    @property
     def with_ctdb(self) -> bool:
         return CTDB in self.iconfig.get(FEATURES, [])
 

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -489,14 +489,16 @@ class ShareConfig:
         self.name = sharename
         self.iconfig = iconfig or {}
 
+    def _cfg(self) -> dict[str, dict[str, str]]:
+        return self.gconfig.data["shares"][self.name]
+
     def share_options(self) -> typing.Iterable[typing.Tuple[str, str]]:
         """Iterate over share options."""
-        share_section = self.gconfig.data["shares"][self.name]
-        return iter(share_section.get("options", {}).items())
+        return iter(self._cfg().get("options", {}).items())
 
     def path(self) -> typing.Optional[str]:
         """Return the path value from the smb.conf options."""
-        share_section = self.gconfig.data["shares"][self.name]
+        share_section = self._cfg()
         try:
             return share_section["options"]["path"]
         except KeyError:
@@ -508,7 +510,7 @@ class ShareConfig:
         # but if it does not it will default to the instance's
         # config
         try:
-            share_perms = self.gconfig.data["shares"][self.name]["permissions"]
+            share_perms = self._cfg()["permissions"]
             return PermissionsConfig(share_perms)
         except KeyError:
             pass
@@ -519,6 +521,24 @@ class ShareConfig:
             pass
         # use the internal defaults
         return PermissionsConfig({})
+
+    def meta(self) -> ShareMeta:
+        """Return a share meta configuration for the share."""
+        # each share can have it's own meta config,
+        # but if it does not it will default to the instance's
+        # share meta config
+        try:
+            share_meta = self._cfg()["meta"]
+            return ShareMeta(share_meta)
+        except KeyError:
+            pass
+        try:
+            instance_meta = self.iconfig["sharemeta"]
+            return ShareMeta(instance_meta)
+        except KeyError:
+            pass
+        # use the internal defaults
+        return ShareMeta({})
 
 
 class UserEntry:
@@ -668,6 +688,29 @@ class PermissionsConfig:
     def options(self) -> dict[str, str]:
         filter_keys = {self._method_key, self._status_xattr_key}
         return {k: v for k, v in self._pconf.items() if k not in filter_keys}
+
+
+class ShareOrigin(enum.Enum):
+    UNKNOWN = "unknown"
+    LOCAL = "local"  # media local to host
+    SHARED = "shared"  # shared media
+    VIRTUAL = "virtual"  # media not accessible by posix apis
+
+
+class ShareMeta:
+    def __init__(self, mconf: dict[str, str]) -> None:
+        self._mconf = mconf
+
+    @property
+    def origin(self) -> ShareOrigin:
+        """Return the origin (kind of path) that a share is based on.
+        Defaults to 'shared' as historically that's what other parts of sambacc
+        assumed.
+        """
+        try:
+            return ShareOrigin(self._mconf.get("origin", "shared"))
+        except (KeyError, ValueError):
+            return ShareOrigin.UNKNOWN
 
 
 class KeyBridgeScopeConfig:

--- a/sambacc/nsswitch_loader.py
+++ b/sambacc/nsswitch_loader.py
@@ -62,3 +62,16 @@ class NameServiceSwitchLoader(TextFileLoader):
         gidx = self.idx["group"]
         if "winbind" not in self.lines[gidx]:
             self.lines[gidx] = "group:    files winbind\n"
+
+    def altfiles_enabled(self) -> bool:
+        pline = self.lines[self.idx["passwd"]]
+        gline = self.lines[self.idx["group"]]
+        return ("altfiles" in pline) and ("altfiles" in gline)
+
+    def ensure_altfiles_enabled(self) -> None:
+        pidx = self.idx["passwd"]
+        if "altfiles" not in self.lines[pidx]:
+            self.lines[pidx] = "passwd:    files altfiles\n"
+        gidx = self.idx["group"]
+        if "altfiles" not in self.lines[gidx]:
+            self.lines[gidx] = "group:    files altfiles\n"

--- a/sambacc/nsswitch_loader.py
+++ b/sambacc/nsswitch_loader.py
@@ -75,3 +75,19 @@ class NameServiceSwitchLoader(TextFileLoader):
         gidx = self.idx["group"]
         if "altfiles" not in self.lines[gidx]:
             self.lines[gidx] = "group:    files altfiles\n"
+
+
+NSSWITCH_PATHS = ["/etc/nsswitch.conf", "/usr/etc/nsswitch.conf"]
+NSSWITCH_DEST = "/etc/nsswitch.conf"
+
+
+def find(paths: typing.Optional[list[str]] = None) -> NameServiceSwitchLoader:
+    paths = paths or NSSWITCH_PATHS
+    for path in paths:
+        nss = NameServiceSwitchLoader(path)
+        try:
+            nss.read()
+            return nss
+        except FileNotFoundError:
+            pass
+    raise FileNotFoundError(f"Failed to open {' or '.join(paths)}")

--- a/sambacc/paths.py
+++ b/sambacc/paths.py
@@ -55,3 +55,21 @@ def ensure_share_dirs(path: str, root: str = "/") -> None:
         path = path[1:]
     path = os.path.join(root, path)
     os.makedirs(path, exist_ok=True)
+
+
+def ensure_symlink(src: str, dst: str, update: bool = True) -> None:
+    """Ensure that a given dst symlink exists and points at src.
+    If update is False, then a preexisting dst is not raised as an error.
+    """
+    try:
+        os.symlink(src, dst)
+        return
+    except FileExistsError:
+        # dst exists but we will ignore it if update is False
+        if not update:
+            return
+    lnk = os.readlink(dst)  # this will raise if dst is not a link
+    if lnk == src:
+        return
+    os.unlink(dst)
+    os.symlink(src, dst)  # raise if we fail to make a new symlink

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -19,12 +19,15 @@
 import argparse
 import functools
 import os
+import unittest.mock
 
 import sambacc.config
 import sambacc.opener
 import sambacc.paths
+import sambacc.passdb_loader
 
 import sambacc.commands.config
+import sambacc.commands.cli
 
 
 config1 = """
@@ -98,9 +101,21 @@ class FakeContext:
         self.require_validation = False
 
     @classmethod
-    def defaults(cls, cfg_path, watch=False, signal_pids_dir=None):
+    def defaults(
+        cls, cfg_path, watch=False, signal_pids_dir=None, tmpdir=None
+    ):
         with open(cfg_path, "w") as fh:
             fh.write(config1)
+        if tmpdir:
+            pl = sambacc.commands.cli.AltLocation.parse(
+                f"/foo/passwd:{tmpdir}/"
+            )
+            gl = sambacc.commands.cli.AltLocation.parse(
+                f"/foo/group:{tmpdir}/"
+            )
+        else:
+            pl = sambacc.commands.cli.AltLocation("/foo/passwd")
+            gl = sambacc.commands.cli.AltLocation("/foo/group")
 
         config = [cfg_path]
         identity = "updateme"
@@ -110,6 +125,8 @@ class FakeContext:
                 "signal_pids_dir": signal_pids_dir,
                 "config": config,
                 "identity": identity,
+                "passwd_location": pl,
+                "group_location": gl,
             },
             sambacc.config.read_config_files(config).get(identity),
         )
@@ -156,7 +173,7 @@ def test_update_config_changed(tmp_path, monkeypatch):
     _gen_fake_cmd(fake, str(chkpath))
     monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
 
-    ctx = FakeContext.defaults(cfg_path)
+    ctx = FakeContext.defaults(cfg_path, tmpdir=tmp_path)
     with open(cfg_path, "w") as fh:
         fh.write(config2)
     monkeypatch.setattr(
@@ -165,6 +182,11 @@ def test_update_config_changed(tmp_path, monkeypatch):
         functools.partial(
             sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
         ),
+    )
+    monkeypatch.setattr(
+        sambacc.commands.config,
+        "sync_passdb_users",
+        unittest.mock.MagicMock(),
     )
     sambacc.commands.config.update_config(ctx)
 
@@ -184,7 +206,7 @@ def test_update_config_smbcontrol_fails(tmp_path, monkeypatch, caplog):
     _gen_fake_cmd(fake, str(chkpath), fail_cmd="smbcontrol")
     monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
 
-    ctx = FakeContext.defaults(cfg_path)
+    ctx = FakeContext.defaults(cfg_path, tmpdir=tmp_path)
     with open(cfg_path, "w") as fh:
         fh.write(config2)
     monkeypatch.setattr(
@@ -193,6 +215,11 @@ def test_update_config_smbcontrol_fails(tmp_path, monkeypatch, caplog):
         functools.partial(
             sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
         ),
+    )
+    monkeypatch.setattr(
+        sambacc.commands.config,
+        "sync_passdb_users",
+        unittest.mock.MagicMock(),
     )
     with caplog.at_level("WARNING"):
         sambacc.commands.config.update_config(ctx)
@@ -214,7 +241,7 @@ def test_update_config_changed_ctdb(tmp_path, monkeypatch):
     _gen_fake_cmd(fake, str(chkpath))
     monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
 
-    ctx = FakeContext.defaults(cfg_path)
+    ctx = FakeContext.defaults(cfg_path, tmpdir=tmp_path)
     ctx.instance_config.iconfig["instance_features"] = ["ctdb"]
     assert ctx.instance_config.with_ctdb
     with open(cfg_path, "w") as fh:
@@ -225,6 +252,11 @@ def test_update_config_changed_ctdb(tmp_path, monkeypatch):
         functools.partial(
             sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
         ),
+    )
+    monkeypatch.setattr(
+        sambacc.commands.config,
+        "sync_passdb_users",
+        unittest.mock.MagicMock(),
     )
     sambacc.commands.config.update_config(ctx)
 
@@ -241,7 +273,7 @@ def test_update_config_ctdb_notleader(tmp_path, monkeypatch):
     _gen_fake_cmd(fake, str(chkpath), pnn="")
     monkeypatch.setattr(sambacc.samba_cmds, "_GLOBAL_PREFIX", [str(fake)])
 
-    ctx = FakeContext.defaults(cfg_path)
+    ctx = FakeContext.defaults(cfg_path, tmpdir=tmp_path)
     ctx.instance_config.iconfig["instance_features"] = ["ctdb"]
     assert ctx.instance_config.with_ctdb
     with open(cfg_path, "w") as fh:
@@ -252,6 +284,11 @@ def test_update_config_ctdb_notleader(tmp_path, monkeypatch):
         functools.partial(
             sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
         ),
+    )
+    monkeypatch.setattr(
+        sambacc.commands.config,
+        "sync_passdb_users",
+        unittest.mock.MagicMock(),
     )
     sambacc.commands.config.update_config(ctx)
 
@@ -279,13 +316,18 @@ def test_update_config_watch_waiter_expires(tmp_path, monkeypatch):
 
     monkeypatch.setattr(sambacc.commands.config, "best_waiter", _fake_waiter)
 
-    ctx = FakeContext.defaults(cfg_path, watch=True)
+    ctx = FakeContext.defaults(cfg_path, watch=True, tmpdir=tmp_path)
     monkeypatch.setattr(
         sambacc.paths,
         "ensure_share_dirs",
         functools.partial(
             sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
         ),
+    )
+    monkeypatch.setattr(
+        sambacc.commands.config,
+        "sync_passdb_users",
+        unittest.mock.MagicMock(),
     )
     sambacc.commands.config.update_config(ctx)
 
@@ -317,13 +359,18 @@ def test_update_config_watch_waiter_trigger3(tmp_path, monkeypatch):
     monkeypatch.setattr(sambacc.commands.config, "best_waiter", _fake_waiter)
     fake_waiter.on_count[3] = _new_conf
 
-    ctx = FakeContext.defaults(cfg_path, watch=True)
+    ctx = FakeContext.defaults(cfg_path, watch=True, tmpdir=tmp_path)
     monkeypatch.setattr(
         sambacc.paths,
         "ensure_share_dirs",
         functools.partial(
             sambacc.paths.ensure_share_dirs, root=str(tmp_path / "_root")
         ),
+    )
+    monkeypatch.setattr(
+        sambacc.commands.config,
+        "sync_passdb_users",
+        unittest.mock.MagicMock(),
     )
     sambacc.commands.config.update_config(ctx)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
 
+from unittest import mock
+
 import pytest
 
 import sambacc.commands.cli
@@ -60,3 +62,126 @@ def test_print_config_env_vars(capsys, tmp_path, monkeypatch):
     assert "path = /share" in out
     assert "[stuff]" in out
     assert "path = /mnt/stuff" in out
+
+
+@pytest.fixture(scope="function")
+def clihack(tmp_path, monkeypatch):
+    mm = mock.MagicMock()
+
+    mm.tcmds = sambacc.commands.cli.CommandBuilder()
+
+    @mm.tcmds.command("check")
+    def _check(ctx):
+        mm.check(ctx)
+
+    mm.fname = tmp_path / "sample.json"
+    with open(mm.fname, "w") as fh:
+        fh.write(config1)
+
+    def _run(args):
+        for key, value in mm.test_env.items():
+            monkeypatch.setenv(key, value)
+        sambacc.commands.main.main_command(mm.tcmds, args)
+
+    mm.run = _run
+    return mm
+
+
+def test_cli_simple(clihack):
+    def _assert(ctx):
+        assert ctx.cli.config == [str(clihack.fname)]
+        assert ctx.cli.identity == "foobar"
+
+    clihack.test_env = {
+        "SAMBACC_CONFIG": str(clihack.fname),
+        "SAMBA_CONTAINER_ID": "foobar",
+    }
+    clihack.check = _assert
+    clihack.run(["check"])
+
+
+def test_cli_opts_simple(clihack):
+    def _assert(ctx):
+        assert ctx.cli.config == [str(clihack.fname)]
+        assert ctx.cli.identity == "foobar"
+
+    clihack.test_env = {}
+    clihack.check = _assert
+    clihack.run(["--identity=foobar", f"--config={clihack.fname}", "check"])
+
+
+def test_cli_altfiles_default(clihack):
+    def _assert(ctx):
+        assert ctx.cli.passwd_location.default_path == "/etc/passwd"
+        assert not ctx.cli.passwd_location.altfiles
+        assert ctx.cli.group_location.default_path == "/etc/group"
+        assert not ctx.cli.group_location.altfiles
+
+    clihack.test_env = {
+        "SAMBACC_CONFIG": str(clihack.fname),
+        "SAMBA_CONTAINER_ID": "foobar",
+    }
+    clihack.check = _assert
+    clihack.run(["check"])
+
+
+def test_cli_altfiles_opts(clihack):
+    def _assert(ctx):
+        assert ctx.cli.passwd_location.default_path == "/etc/passwd"
+        assert ctx.cli.passwd_location.altfiles
+        assert (
+            ctx.cli.passwd_location.mutable_path == "/var/lib/samba/passwd.txt"
+        )
+        assert ctx.cli.passwd_location.link_path == "/lib/passwd"
+
+        assert ctx.cli.group_location.default_path == "/etc/group"
+        assert ctx.cli.group_location.altfiles
+        assert (
+            ctx.cli.group_location.mutable_path == "/var/lib/samba/group.txt"
+        )
+        assert ctx.cli.group_location.link_path == "/lib/group"
+
+    clihack.test_env = {
+        "SAMBACC_CONFIG": str(clihack.fname),
+        "SAMBA_CONTAINER_ID": "foobar",
+    }
+    clihack.check = _assert
+    clihack.run(
+        [
+            "--passwd-location",
+            "/etc/passwd:/var/lib/samba/passwd.txt:/lib/passwd",
+            "--group-location",
+            "/etc/group:/var/lib/samba/group.txt:/lib/group",
+            "check",
+        ]
+    )
+
+
+def test_cli_altfiles_env(clihack):
+    def _assert(ctx):
+        assert ctx.cli.passwd_location.default_path == "/etc/passwd"
+        assert ctx.cli.passwd_location.altfiles
+        assert (
+            ctx.cli.passwd_location.mutable_path == "/var/lib/samba/passwd.txt"
+        )
+        assert ctx.cli.passwd_location.link_path == "/lib/passwd"
+
+        assert ctx.cli.group_location.default_path == "/etc/group"
+        assert ctx.cli.group_location.altfiles
+        assert (
+            ctx.cli.group_location.mutable_path == "/var/lib/samba/group.txt"
+        )
+        assert ctx.cli.group_location.link_path == "/lib/group"
+
+    clihack.test_env = {
+        "SAMBACC_CONFIG": str(clihack.fname),
+        "SAMBA_CONTAINER_ID": "foobar",
+        "SAMBACC_PASSWD_LOCATION": (
+            "/etc/passwd:/var/lib/samba/passwd.txt:/lib/passwd"
+        ),
+        "SAMBACC_GROUP_LOCATION": (
+            "/etc/group:/var/lib/samba/group.txt:/lib/group"
+        ),
+    }
+    clihack.check = _assert
+    clihack.run(["check"])


### PR DESCRIPTION
This began purely as a set of experiments on sambacc to see if we could solve the issue that the configwatch could not update the /etc/passwd file of the smbd container on ceph. I began looking at the altfiles nsswitch module (available as a package on our supported container distros) and because I tend to think in code it was easier to try things and eventually got to the point where I might as well make a PR.

TODO
* [x] Clean up patches into something reviewable
* [x] Investigate / test when running in CTDB with configwatch (leader / not leader, etc)
* [x] Make a decision WRT the mutable passwd/group files needing to exist in order to write them - either fix <s>or decide its an OK prereq</s>
* [x] test split up config watch functions

What I manually tested:
* Build samba-container with the `nss-altfiles` package included
* A user-auth single node "cluster" running on ceph (with a few hacks applied to cephadm)
 * Basic setup worked (after fixes)
 * User added to the list worked (after fixes)
 * ctdb enabled configured for local users/gropus - deploy and update