### PR TITLE
Support adding local users to local groups

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,6 +247,7 @@ The `groups` section supports one key, `all_entries`, which is a list of
 group entries. Each group entry is as follows:
 * `name` - The user's name.
 * `gid` - Optional integer. Specify the exact Unix GID the group should have.
+* `members` - Optional list of strings. User names that are members of the group.
 
 
 ## Domain Settings Section

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -614,9 +614,12 @@ class GroupEntry:
         self.entry_num = num
         self._gid = grec.get("gid")
         self.ou = grec.get("ou")
+        self.members: list[str] = grec.get("members", [])
         if self._gid is not None:
             if not isinstance(self._gid, int):
                 raise ValueError("invalid gid value")
+        if not isinstance(self.members, list):
+            raise ValueError("members should contain a list of user names")
 
     @property
     def gid(self) -> int:
@@ -626,7 +629,7 @@ class GroupEntry:
 
     def group_fields(self) -> GroupEntryTuple:
         # fields: name, passwd, gid, members(comma separated)
-        return (self.groupname, "x", str(self.gid), "")
+        return (self.groupname, "x", str(self.gid), ",".join(self.members))
 
 
 class DomainConfig:

--- a/sambacc/passwd_loader.py
+++ b/sambacc/passwd_loader.py
@@ -82,7 +82,24 @@ class GroupFileLoader(LineFileLoader):
 
     def add_group(self, group_entry: config.GroupEntry) -> None:
         if group_entry.groupname in self._groupnames:
+            self._update_group_members(group_entry)
             return
         line = "{}\n".format(":".join(group_entry.group_fields()))
         self.lines.append(line)
         self._groupnames.add(group_entry.groupname)
+
+    def _update_group_members(self, group_entry: config.GroupEntry) -> None:
+        new_members = group_entry.group_fields()[3]
+        for idx, line in enumerate(self.lines):
+            if ":" not in line:
+                continue
+            fields = line.rstrip("\n").split(":")
+            if len(fields) < 4:
+                continue
+            if fields[0] != group_entry.groupname:
+                continue
+            if fields[3] == new_members:
+                return
+            fields[3] = new_members
+            self.lines[idx] = "{}\n".format(":".join(fields))
+            return

--- a/sambacc/schema/conf-v0.schema.json
+++ b/sambacc/schema/conf-v0.schema.json
@@ -87,6 +87,13 @@
         "gid": {
           "description": "The Unix GID the group should have",
           "type": "integer"
+        },
+        "members": {
+          "description": "List of usernames that belong to this group",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [

--- a/sambacc/schema/conf-v0.schema.yaml
+++ b/sambacc/schema/conf-v0.schema.yaml
@@ -97,6 +97,11 @@ $defs:
       gid:
         description: The Unix GID the group should have
         type: integer
+      members:
+        description: List of usernames that belong to this group
+        type: array
+        items:
+          type: string
     required:
       - name
     additionalProperties: false

--- a/sambacc/schema/conf_v0_schema.py
+++ b/sambacc/schema/conf_v0_schema.py
@@ -103,6 +103,13 @@ SCHEMA = {
                     "description": "The Unix GID the group should have",
                     "type": "integer",
                 },
+                "members": {
+                    "description": (
+                        "List of usernames that belong to this group"
+                    ),
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
             },
             "required": ["name"],
             "additionalProperties": False,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -166,6 +166,47 @@ config3 = """
 }
 """
 
+config4 = """
+{
+  "samba-container-config": "v0",
+  "configs": {
+    "foobar": {
+      "shares": ["share"],
+      "globals": ["global0"],
+      "instance_name": "GANDOLPH"
+    }
+  },
+  "shares": {
+    "share": {
+      "options": {
+        "path": "/share"
+      }
+    }
+  },
+  "globals": {
+    "global0": {
+      "options": {
+        "security": "user"
+      }
+    }
+  },
+  "users": {
+      "all_entries": [
+        {"name": "alice", "uid": 2001, "gid": 2001,
+         "password": "123fakeStreet"},
+        {"name": "bob", "uid": 2002, "gid": 2002,
+         "password": "notSoSafe"}
+      ]
+  },
+  "groups": {
+      "all_entries": [
+        {"name": "readers", "gid": 3000, "members": ["alice", "bob"]},
+        {"name": "writers", "gid": 3001, "members": ["alice"]}
+      ]
+  }
+}
+"""
+
 ctdb_config1 = """
 {
   "samba-container-config": "v0",
@@ -470,6 +511,36 @@ class TestConfig(unittest.TestCase):
         assert groups[1].gid == 2001
         assert groups[2].groupname == "carol"
         assert groups[2].gid == 1002
+
+    def test_group_entry_with_members(self):
+        fh = io.StringIO(config4)
+        g = sambacc.config.GlobalConfig(fh)
+        ic = g.get("foobar")
+        groups = list(ic.groups())
+        assert groups[0].groupname == "readers"
+        assert groups[0].members == ["alice", "bob"]
+        assert groups[0].group_fields() == (
+            "readers",
+            "x",
+            "3000",
+            "alice,bob",
+        )
+        assert groups[1].groupname == "writers"
+        assert groups[1].members == ["alice"]
+        assert groups[1].group_fields() == ("writers", "x", "3001", "alice")
+
+    def test_group_entry_without_members(self):
+        fh = io.StringIO(config3)
+        g = sambacc.config.GlobalConfig(fh)
+        ic = g.get("foobar")
+        groups = list(ic.groups())
+        assert groups[0].members == []
+        assert groups[0].group_fields()[3] == ""
+
+    def test_invalid_group_members(self):
+        rec = {"name": "foo", "members": "not_a_list"}
+        with pytest.raises(ValueError):
+            sambacc.config.GroupEntry(None, rec, 0)
 
 
 def test_read_config_files(tmpdir):

--- a/tests/test_passwd_loader.py
+++ b/tests/test_passwd_loader.py
@@ -1,7 +1,7 @@
 import io
 
 import sambacc.passwd_loader
-from .test_config import config2
+from .test_config import config2, config4
 
 etc_passwd1 = """
 root:x:0:0:root:/root:/bin/bash
@@ -152,3 +152,59 @@ def test_write_passwd_file(tmp_path):
     assert "\nalice:x:" in txt
     assert "\nbob:x:" in txt
     assert "\ncarol:x:" in txt
+
+
+def test_add_group_with_members():
+    fh = io.StringIO(config4)
+    g = sambacc.config.GlobalConfig(fh)
+    ic = g.get("foobar")
+    groups = list(ic.groups())
+
+    gfl = sambacc.passwd_loader.GroupFileLoader()
+    for grp in groups:
+        gfl.add_group(grp)
+    fh2 = io.StringIO()
+    gfl.writefp(fh2)
+    txt = fh2.getvalue()
+    assert "readers:x:3000:alice,bob" in txt
+    assert "writers:x:3001:alice" in txt
+
+
+def test_add_group_updates_members_on_existing():
+    fh = io.StringIO(etc_group1)
+    gfl = sambacc.passwd_loader.GroupFileLoader()
+    gfl.readfp(fh)
+    original_count = len(gfl.lines)
+
+    fh2 = io.StringIO(config4)
+    g = sambacc.config.GlobalConfig(fh2)
+    ic = g.get("foobar")
+
+    rec = {"name": "wheel", "gid": 10, "members": ["alice", "bob"]}
+    wheel = sambacc.config.GroupEntry(ic, rec, 0)
+    gfl.add_group(wheel)
+
+    assert len(gfl.lines) == original_count
+    fh3 = io.StringIO()
+    gfl.writefp(fh3)
+    txt = fh3.getvalue()
+    assert "wheel:x:10:alice,bob" in txt
+
+
+def test_add_group_idempotent_members():
+    fh = io.StringIO(config4)
+    g = sambacc.config.GlobalConfig(fh)
+    ic = g.get("foobar")
+    groups = list(ic.groups())
+
+    gfl = sambacc.passwd_loader.GroupFileLoader()
+    for grp in groups:
+        gfl.add_group(grp)
+    count_after_first = len(gfl.lines)
+    for grp in groups:
+        gfl.add_group(grp)
+    assert len(gfl.lines) == count_after_first
+    fh2 = io.StringIO()
+    gfl.writefp(fh2)
+    txt = fh2.getvalue()
+    assert txt.count("readers:x:3000:alice,bob") == 1


### PR DESCRIPTION
Add support for specifying group membership in local (non-domain) group entries via a new `members` field. This allows configurations like:

  ```json
  "groups": {
      "all_entries": [
          {"name": "readers", "gid": 3000, "members": ["alice", "bob"]},
          {"name": "writers", "gid": 3001, "members": ["alice"]}
      ]
  }
```

Previously, the members field (4th field) in _/etc/group_ lines was always written as an empty string. Groups without members defined keep the previous behavior. _GroupFileLoader.add_group()_ is also updated to modify the members field of existing group lines in place, so that membership changes are picked up during config re-syncs via `update-config`.

fixes #101 