### PR TITLE
tox: Update black version pin and reformat code

### DIFF
--- a/sambacc/_xattr.py
+++ b/sambacc/_xattr.py
@@ -27,7 +27,6 @@ could have been accomplished by writing a pyi file for xattr but since
 we need the runtime support we just add new functions.
 """
 
-
 import pathlib
 import typing
 

--- a/sambacc/addc.py
+++ b/sambacc/addc.py
@@ -103,7 +103,7 @@ def add_group_members(group_name: str, members: list[str]) -> None:
 
 
 def _filter_opts(
-    options: typing.Optional[typing.Iterable[tuple[str, str]]]
+    options: typing.Optional[typing.Iterable[tuple[str, str]]],
 ) -> list[tuple[str, str]]:
     _skip_keys = ["netbios name"]
     options = options or []

--- a/sambacc/ceph/rados.py
+++ b/sambacc/ceph/rados.py
@@ -406,7 +406,7 @@ def is_rados_uri(uri: str) -> bool:
 
 
 def parse_rados_uri(
-    uri: typing.Union[str, urllib.request.Request]
+    uri: typing.Union[str, urllib.request.Request],
 ) -> dict[str, str]:
     """Given a rados uri-like value return a dict containing a breakdown of the
     components of the uri.

--- a/sambacc/commands/cli.py
+++ b/sambacc/commands/cli.py
@@ -76,7 +76,7 @@ def toggle_option(parser: Parser, arg: str, dest: str, helpfmt: str) -> Parser:
 
 
 def ceph_id(
-    value: typing.Union[str, dict[str, typing.Any]]
+    value: typing.Union[str, dict[str, typing.Any]],
 ) -> dict[str, typing.Any]:
     """Parse a string value into a dict containing ceph id values.
     The input should contain name= or rados_id= to identify the kind

--- a/sambacc/commands/dcmain.py
+++ b/sambacc/commands/dcmain.py
@@ -29,7 +29,6 @@ from .common import (
     pre_action,
 )
 
-
 default_cfunc = addc.summary
 
 

--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -27,7 +27,6 @@ from . import config  # noqa: F401
 from . import users  # noqa: F401
 from .cli import commands, perms_handler, setup_steps, Context
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/sambacc/commands/remotecontrol/server.py
+++ b/sambacc/commands/remotecontrol/server.py
@@ -28,7 +28,6 @@ from ..common import CommandContext
 
 import sambacc.grpc.config
 
-
 _logger = logging.getLogger(__name__)
 _AUTO = "auto"  # allow modifications based on conn settings
 _MTLS = "mtls"  # allow modifications based on conn tls settings

--- a/sambacc/commands/run.py
+++ b/sambacc/commands/run.py
@@ -29,7 +29,6 @@ from .cli import commands, Context, Fail
 from .initialize import init_container, setup_step_names
 from .join import join
 
-
 _logger = logging.getLogger(__name__)
 
 INIT_ALL = "init-all"

--- a/sambacc/commands/satellite/keybridge.py
+++ b/sambacc/commands/satellite/keybridge.py
@@ -28,7 +28,6 @@ import sambacc.config
 from ..cli import Context, Fail, commands
 from ..common import CommandContext
 
-
 if typing.TYPE_CHECKING:
     import sambacc.varlink.keybridge
 

--- a/sambacc/grpc/backend.py
+++ b/sambacc/grpc/backend.py
@@ -33,7 +33,6 @@ from sambacc.typelets import Self
 import sambacc.config
 import sambacc.samba_cmds
 
-
 _logger = logging.getLogger(__name__)
 CTDB_CONF_PATH = "/etc/ctdb/ctdb.conf"
 

--- a/sambacc/grpc/rados_checker.py
+++ b/sambacc/grpc/rados_checker.py
@@ -23,7 +23,6 @@ import grpc
 import sambacc.ceph.rados
 import sambacc.grpc.config
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/sambacc/grpc/server.py
+++ b/sambacc/grpc/server.py
@@ -48,7 +48,6 @@ from sambacc.grpc.config import (
     ServerConfig,
 )
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/sambacc/jfile.py
+++ b/sambacc/jfile.py
@@ -15,8 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 #
-"""Utilities for working with JSON data stored in a file system file.
-"""
+"""Utilities for working with JSON data stored in a file system file."""
 
 import fcntl
 import json

--- a/sambacc/kmip/scope.py
+++ b/sambacc/kmip/scope.py
@@ -38,7 +38,6 @@ from sambacc.varlink.keybridge import (
     ScopeInfo,
 )
 
-
 _logger = logging.getLogger(__name__)
 
 # use monotonic if possible, otherwise fall back to traditional time.time.
@@ -58,6 +57,7 @@ class TLSPaths:
 @dataclasses.dataclass
 class _Value:
     "Cached value."
+
     value: bytes
     created: int
 

--- a/sambacc/permissions.py
+++ b/sambacc/permissions.py
@@ -27,7 +27,6 @@ import typing
 
 from sambacc import _xattr as xattr
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/sambacc/schema/tool.py
+++ b/sambacc/schema/tool.py
@@ -13,7 +13,6 @@ import sys
 
 import yaml
 
-
 nameparts = collections.namedtuple("nameparts", "full head ext")
 filepair = collections.namedtuple("filepair", "origin dest format")
 

--- a/sambacc/varlink/keybridge.py
+++ b/sambacc/varlink/keybridge.py
@@ -30,7 +30,6 @@ import varlink  # type: ignore[import]
 from sambacc.typelets import Self
 from .endpoint import VarlinkEndpoint
 
-
 _logger = logging.getLogger(__name__)
 
 
@@ -61,12 +60,14 @@ class KeyBridgeError(varlink.VarlinkError):
 
 class ScopeNotFoundError(KeyBridgeError):
     "ScopeName may be returned if a request refers to an unknown scope."
+
     _name = "ScopeNotFound"
     _expect = {"scope"}
 
 
 class EntryNotFoundError(KeyBridgeError):
     "EntryNotFound may returned if a request refers to an unknown entry."
+
     _name = "EntryNotFound"
     _expect = {"name", "scope"}
 

--- a/sambacc/varlink/server.py
+++ b/sambacc/varlink/server.py
@@ -30,7 +30,6 @@ import varlink.server  # type: ignore[import]
 
 from .endpoint import VarlinkEndpoint
 
-
 _logger = logging.getLogger(__name__)
 
 _VET = typing.Type[varlink.error.VarlinkEncoder]

--- a/tests/test_commands_config.py
+++ b/tests/test_commands_config.py
@@ -29,7 +29,6 @@ import sambacc.passdb_loader
 import sambacc.commands.config
 import sambacc.commands.cli
 
-
 config1 = """
 {
     "samba-container-config": "v0",

--- a/tests/test_container_dns.py
+++ b/tests/test_container_dns.py
@@ -21,7 +21,6 @@ import time
 
 import sambacc.container_dns
 
-
 J1 = """
 {
   "ref": "example",

--- a/tests/test_grpc_backend.py
+++ b/tests/test_grpc_backend.py
@@ -24,7 +24,6 @@ import pytest
 
 import sambacc.grpc.backend
 
-
 config1 = """
 {
   "samba-container-config": "v0",

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,7 @@ allowlist_externals =
 [testenv:formatting]
 description = Check the style/formatting for the source files
 deps =
-    black>=24, <25
+    black>=25, <26
 commands =
     black --check -v --extend-exclude sambacc/grpc/generated .
 
@@ -75,7 +75,7 @@ commands =
 [testenv:schemacheck]
 description = Check the JSON Schema files are valid
 deps =
-    black>=24, <25
+    black>=25, <26
     PyYAML
 commands =
     python -m sambacc.schema.tool
@@ -83,7 +83,7 @@ commands =
 [testenv:schemaupdate]
 description = Regenerate source files from JSON Schema file(s)
 deps =
-    black>=24, <25
+    black>=25, <26
     PyYAML
 commands =
     python -m sambacc.schema.tool --update


### PR DESCRIPTION
Note: The upper bound <26 is required because black 26.x introduces _multiline_string_handling_ in its 2026 stable style https://github.com/psf/black/issues/4875, which produces incompatible formatting for multiline string arguments. Since CentOS Stream 9 can only get till black 25.x, we pin to that range to keep CI consistent across environments.

updates https://github.com/samba-in-kubernetes/sambacc/issues/100