### PR TITLE
schema: add meta/sharemeta support for share origin config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -168,6 +168,9 @@ Each configuration section is as follows:
   configurations.
 * `domain_settings` - String. Name of the AD DC domain configuration. Required
   for AD DC configurations, invalid for all others.
+* `sharemeta` - Share metadata section. Default metadata for shares that
+  don't specify their own `meta` section. Same fields as the `meta` section
+  described under the Shares Section, below.
 
 The subsections under `configs` can be used to uniquely identify one server
 "instance". Because those server instances may repeat the shares and samba
@@ -193,6 +196,9 @@ Each share configuration section is as follows:
   * `status_xattr` - Name of xattr to store status.
   * Remaining key-value pairs are method specific. Unknown keys are ignored.
   * `mode` - String that converts to octal. Unix permissions to set (`initialize-share-perms`, `always-share-perms`).
+* `meta` - Share metadata section:
+  * `origin` - Classifies where the share's storage lives. One of `unknown`,
+    `local`, `shared` (default), `virtual`.
 
 
 ## Globals Section

--- a/sambacc/schema/conf-v0.schema.json
+++ b/sambacc/schema/conf-v0.schema.json
@@ -29,6 +29,23 @@
         "type": "string"
       }
     },
+    "share_meta_config": {
+      "description": "Metadata about a share's storage.\n",
+      "type": "object",
+      "properties": {
+        "origin": {
+          "description": "The kind of storage the share is based on. \"local\" storage should\nbe set up on every CTDB cluster node; \"shared\" storage (the\ndefault) only needs setup on the cluster leader; \"virtual\" storage\nis not accessible via POSIX apis.\n",
+          "type": "string",
+          "enum": [
+            "unknown",
+            "local",
+            "shared",
+            "virtual"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
     "permissions_config": {
       "description": "Settings that enable and manage sambacc's permissions management support.\n",
       "type": "object",
@@ -208,6 +225,9 @@
           "permissions": {
             "$ref": "#/$defs/permissions_config"
           },
+          "sharemeta": {
+            "$ref": "#/$defs/share_meta_config"
+          },
           "instance_name": {
             "description": "A name that will be set for the server instance.\n",
             "type": "string"
@@ -231,6 +251,9 @@
           },
           "permissions": {
             "$ref": "#/$defs/permissions_config"
+          },
+          "meta": {
+            "$ref": "#/$defs/share_meta_config"
           }
         },
         "additionalProperties": false

--- a/sambacc/schema/conf-v0.schema.yaml
+++ b/sambacc/schema/conf-v0.schema.yaml
@@ -44,6 +44,25 @@ $defs:
     type: object
     additionalProperties:
       type: string
+  # metadata describing where a share's storage is hosted
+  share_meta_config:
+    description: |
+      Metadata about a share's storage.
+    type: object
+    properties:
+      origin:
+        description: |
+          The kind of storage the share is based on. "local" storage should
+          be set up on every CTDB cluster node; "shared" storage (the
+          default) only needs setup on the cluster leader; "virtual" storage
+          is not accessible via POSIX apis.
+        type: string
+        enum:
+          - unknown
+          - local
+          - shared
+          - virtual
+    additionalProperties: false
   # permissions backend configurations
   # each backend may have its own set of additional properties
   permissions_config:
@@ -202,6 +221,8 @@ properties:
           $ref: "#/$defs/feature_flags"
         permissions:
           $ref: "#/$defs/permissions_config"
+        sharemeta:
+          $ref: "#/$defs/share_meta_config"
         instance_name:
           description: |
             A name that will be set for the server instance.
@@ -225,6 +246,8 @@ properties:
           $ref: "#/$defs/samba_options"
         permissions:
           $ref: "#/$defs/permissions_config"
+        meta:
+          $ref: "#/$defs/share_meta_config"
       additionalProperties: false
   # globals definitions.
   globals:

--- a/sambacc/schema/conf_v0_schema.py
+++ b/sambacc/schema/conf_v0_schema.py
@@ -41,6 +41,24 @@ SCHEMA = {
             "type": "object",
             "additionalProperties": {"type": "string"},
         },
+        "share_meta_config": {
+            "description": "Metadata about a share's storage.\n",
+            "type": "object",
+            "properties": {
+                "origin": {
+                    "description": (
+                        'The kind of storage the share is based on. "local"'
+                        " storage should\nbe set up on every CTDB cluster"
+                        ' node; "shared" storage (the\ndefault) only needs'
+                        ' setup on the cluster leader; "virtual" storage\nis'
+                        " not accessible via POSIX apis.\n"
+                    ),
+                    "type": "string",
+                    "enum": ["unknown", "local", "shared", "virtual"],
+                }
+            },
+            "additionalProperties": False,
+        },
         "permissions_config": {
             "description": (
                 "Settings that enable and manage sambacc's permissions"
@@ -219,6 +237,7 @@ SCHEMA = {
                     "globals": {"$ref": "#/$defs/section_choices"},
                     "instance_features": {"$ref": "#/$defs/feature_flags"},
                     "permissions": {"$ref": "#/$defs/permissions_config"},
+                    "sharemeta": {"$ref": "#/$defs/share_meta_config"},
                     "instance_name": {
                         "description": (
                             "A name that will be set for the server"
@@ -250,6 +269,7 @@ SCHEMA = {
                 "properties": {
                     "options": {"$ref": "#/$defs/samba_options"},
                     "permissions": {"$ref": "#/$defs/permissions_config"},
+                    "meta": {"$ref": "#/$defs/share_meta_config"},
                 },
                 "additionalProperties": False,
             },


### PR DESCRIPTION
Adds schema support for the meta (per-share) and sharemeta config keys used to classify a share's origin (local/shared/virtual),
plus doc changes for adding new meta property.

Fixes: https://github.com/samba-in-kubernetes/sambacc/issues/220