### PR TITLE
config: Validate and deduplicate group members list

### DIFF
--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -614,12 +614,14 @@ class GroupEntry:
         self.entry_num = num
         self._gid = grec.get("gid")
         self.ou = grec.get("ou")
-        self.members: list[str] = grec.get("members", [])
+        members = grec.get("members", [])
+        if not isinstance(members, list):
+            raise ValueError("members should contain a list of user names")
+        # use dict.fromkeys to deduplicate while preserving order
+        self.members: list[str] = list(dict.fromkeys(members))
         if self._gid is not None:
             if not isinstance(self._gid, int):
                 raise ValueError("invalid gid value")
-        if not isinstance(self.members, list):
-            raise ValueError("members should contain a list of user names")
 
     @property
     def gid(self) -> int:

--- a/sambacc/config.py
+++ b/sambacc/config.py
@@ -314,10 +314,21 @@ class InstanceConfig:
             yield UserEntry(self, entry, n)
 
     def groups(self) -> typing.Iterable[GroupEntry]:
-        user_gids = {u.gid: u for u in self.users()}
+        users = list(self.users())
+        user_gids = {}
+        user_names = set()
+        for u in users:
+            user_gids[u.gid] = u
+            user_names.add(u.username)
         all_groups = self.gconfig.data.get("groups", {}).get("all_entries", {})
         for n, entry in enumerate(all_groups):
             ge = GroupEntry(self, entry, n)
+            invalid = set(ge.members) - user_names
+            if invalid:
+                raise ValueError(
+                    f"group {ge.groupname!r} has members not defined"
+                    f" in users: {', '.join(sorted(invalid))}"
+                )
             if ge.gid in user_gids:
                 del user_gids[ge.gid]
             yield ge

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -542,6 +542,11 @@ class TestConfig(unittest.TestCase):
         with pytest.raises(ValueError):
             sambacc.config.GroupEntry(None, rec, 0)
 
+    def test_duplicate_group_members(self):
+        rec = {"name": "foo", "gid": 100, "members": ["alice", "bob", "alice"]}
+        ge = sambacc.config.GroupEntry(None, rec, 0)
+        assert ge.members == ["alice", "bob"]
+
 
 def test_read_config_files(tmpdir):
     fname = tmpdir / "sample.json"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -207,6 +207,44 @@ config4 = """
 }
 """
 
+config5 = """
+{
+  "samba-container-config": "v0",
+  "configs": {
+    "foobar": {
+      "shares": ["share"],
+      "globals": ["global0"],
+      "instance_name": "GANDOLPH"
+    }
+  },
+  "shares": {
+    "share": {
+      "options": {
+        "path": "/share"
+      }
+    }
+  },
+  "globals": {
+    "global0": {
+      "options": {
+        "security": "user"
+      }
+    }
+  },
+  "users": {
+      "all_entries": [
+        {"name": "alice", "uid": 2001, "gid": 2001,
+         "password": "123fakeStreet"}
+      ]
+  },
+  "groups": {
+      "all_entries": [
+        {"name": "readers", "gid": 3000, "members": ["alice", "allice"]}
+      ]
+  }
+}
+"""
+
 ctdb_config1 = """
 {
   "samba-container-config": "v0",
@@ -546,6 +584,13 @@ class TestConfig(unittest.TestCase):
         rec = {"name": "foo", "gid": 100, "members": ["alice", "bob", "alice"]}
         ge = sambacc.config.GroupEntry(None, rec, 0)
         assert ge.members == ["alice", "bob"]
+
+    def test_invalid_group_member_names(self):
+        fh = io.StringIO(config5)
+        g = sambacc.config.GlobalConfig(fh)
+        ic = g.get("foobar")
+        with pytest.raises(ValueError, match="allice"):
+            list(ic.groups())
 
 
 def test_read_config_files(tmpdir):


### PR DESCRIPTION
- Silently deduplicate group members list during construction, preserving insertion order
- Validate that user names in a group's members field are defined in the configuration

fixes #222 