### PR TITLE
sambacc/commands: Add share_paths to default setup steps

### DIFF
--- a/sambacc/commands/initialize.py
+++ b/sambacc/commands/initialize.py
@@ -122,6 +122,7 @@ def ensure_share_paths(ctx: Context) -> None:
 
 _default_setup_steps = [
     "config",
+    "share_paths",
     "smb_ctdb",
     "nsswitch_auto",
     "users",


### PR DESCRIPTION
Ensure share directories and permissions are set up during default container initialization so that standalone deployments not using configwatch also get automatic path setup.

fixes #58 